### PR TITLE
Bugfix minimum size

### DIFF
--- a/dist/SplitPanel.js
+++ b/dist/SplitPanel.js
@@ -1,7 +1,7 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -43,559 +43,584 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
  * used for all remaining elements. Any additional weights will be ignored.
  */
 var SplitPanel = function (_React$Component) {
-  _inherits(SplitPanel, _React$Component);
+    _inherits(SplitPanel, _React$Component);
 
-  function SplitPanel() {
-    _classCallCheck(this, SplitPanel);
+    function SplitPanel() {
+        _classCallCheck(this, SplitPanel);
 
-    var _this = _possibleConstructorReturn(this, (SplitPanel.__proto__ || Object.getPrototypeOf(SplitPanel)).call(this));
+        var _this = _possibleConstructorReturn(this, (SplitPanel.__proto__ || Object.getPrototypeOf(SplitPanel)).call(this));
 
-    _this.state = {
-      // The last position of the cursor. Used by onMouseMove to calculate
-      // relative changes in divider position.
-      lastCursorPosition: 0,
-      // Sizes of the subpanels taking into account the weights and divider
-      // size.
-      sizes: [],
-      // Offsets of each subpanel.
-      offsets: [],
-      // The index of the divider currently being dragged by the user.
-      activeDividerIndex: -1
-    };
+        _this.state = {
+            // The last position of the cursor. Used by onMouseMove to calculate
+            // relative changes in divider position.
+            lastCursorPosition: 0,
+            // Sizes of the subpanels taking into account the weights and divider
+            // size.
+            sizes: [],
+            // Offsets of each subpanel.
+            offsets: [],
+            // The index of the divider currently being dragged by the user.
+            activeDividerIndex: -1
+        };
 
-    // Bind event listeners in advance.
-    _this.onDividerMouseDown = _this.onDividerMouseDown.bind(_this);
-    // These two are attached to `window` because sometimes due to glitches we
-    // can't do very much about we'll be unable to move the divider in time to
-    // keep up with the mouse cursor, but we still need to move the divider to
-    // catch up and to release it when the user releases the divider.
-    // N.B. These are attached in componentDidMount and detached in
-    // componentWillUnmount.
-    _this.onMouseMove = _this.onMouseMove.bind(_this);
-    _this.onMouseUp = _this.onMouseUp.bind(_this);
-    _this.doAdjustmentOnMouseUp = true;
-    _this.exitMouseMoveOnViolation = true;
-    _this.adjustOnReceiveProps = true;
-    _this.doAdjustmentOnMouseMove = false;
-    return _this;
-  }
+        // Bind event listeners in advance.
+        _this.onDividerMouseDown = _this.onDividerMouseDown.bind(_this);
+        // These two are attached to `window` because sometimes due to glitches we
+        // can't do very much about we'll be unable to move the divider in time to
+        // keep up with the mouse cursor, but we still need to move the divider to
+        // catch up and to release it when the user releases the divider.
+        // N.B. These are attached in componentDidMount and detached in
+        // componentWillUnmount.
+        _this.onMouseMove = _this.onMouseMove.bind(_this);
+        _this.onMouseUp = _this.onMouseUp.bind(_this);
+        _this.doAdjustmentOnMouseUp = true;
+        _this.exitMouseMoveOnViolation = true;
+        _this.adjustOnReceiveProps = true;
+        _this.doAdjustmentOnMouseMove = false; //Not recommended, seems to cause incorrect results
+        return _this;
+    }
 
-  _createClass(SplitPanel, [{
-    key: "render",
-    value: function render() {
-      var _this2 = this;
+    _createClass(SplitPanel, [{
+        key: "render",
+        value: function render() {
+            var _this2 = this;
 
-      // Create a sized splitPanelItem with a divider for each child, except...
-      var childrenWithDividers = [];
-      var children = _react2.default.Children.toArray(this.props.children);
+            // Create a sized splitPanelItem with a divider for each child, except...
+            var childrenWithDividers = [];
+            var children = _react2.default.Children.toArray(this.props.children);
 
-      var _loop = function _loop(i) {
-        var _style;
+            var _loop = function _loop(i) {
+                var _style;
 
-        var style = (_style = {}, _defineProperty(_style, _this2.cssSizeProperty, _this2.sizes[i]), _defineProperty(_style, _this2.cssOffsetProperty, _this2.offsets[i]), _style);
+                var style = (_style = {}, _defineProperty(_style, _this2.cssSizeProperty, _this2.sizes[i]), _defineProperty(_style, _this2.cssOffsetProperty, _this2.offsets[i]), _style);
 
-        childrenWithDividers.push(_react2.default.createElement(
-          "div",
-          { key: "panel-" + i,
-            className: "split-panel-item",
-            style: style },
-          children[i]
-        ));
+                childrenWithDividers.push(_react2.default.createElement(
+                    "div",
+                    { key: "panel-" + i,
+                        className: "split-panel-item",
+                        style: style },
+                    children[i]
+                ));
 
-        // ...don't add a divider if it's the last panel.
-        if (i < children.length - 1) {
-          var dividerStyle = _defineProperty({}, _this2.cssOffsetProperty, _this2.offsets[i + 1] - _this2.dividerSize);
-          childrenWithDividers.push(_react2.default.createElement("div", {
-            key: "divider-" + i, ref: "divider-" + i,
-            className: "split-panel-divider",
-            style: dividerStyle,
-            onMouseDown: function onMouseDown(e) {
-              return _this2.onDividerMouseDown(e, i);
-            } }));
+                // ...don't add a divider if it's the last panel.
+                if (i < children.length - 1) {
+                    var dividerStyle = _defineProperty({}, _this2.cssOffsetProperty, _this2.offsets[i + 1] - _this2.dividerSize);
+                    childrenWithDividers.push(_react2.default.createElement("div", {
+                        key: "divider-" + i, ref: "divider-" + i,
+                        className: "split-panel-divider",
+                        style: dividerStyle,
+                        onMouseDown: function onMouseDown(e) {
+                            return _this2.onDividerMouseDown(e, i);
+                        } }));
+                }
+            };
+
+            for (var i = 0; i < children.length; i++) {
+                _loop(i);
+            }
+
+            // Because elements don't have a resize event we create an <object> with
+            // no content and filling the entire panel. When this object's
+            // contentDocument.resize event fires we know to update the sizes of all
+            // the subpanels. :-)
+            var resizeHackObject = _react2.default.createElement("object", { className: "split-panel-resize-hack-object",
+                ref: "resizeHackObject",
+                type: "text/html" });
+            var klass = (0, _classnames2.default)("split-panel", this.props.direction, {
+                "split-panel-resizing": this.state.activeDividerIndex != -1
+            });
+            return _react2.default.createElement(
+                "div",
+                { ref: "self", className: klass },
+                resizeHackObject,
+                childrenWithDividers
+            );
         }
-      };
 
-      for (var i = 0; i < children.length; i++) {
-        _loop(i);
-      }
+        //////
+        // Component Lifecycle
+        //////
 
-      // Because elements don't have a resize event we create an <object> with
-      // no content and filling the entire panel. When this object's
-      // contentDocument.resize event fires we know to update the sizes of all
-      // the subpanels. :-)
-      var resizeHackObject = _react2.default.createElement("object", { className: "split-panel-resize-hack-object",
-        ref: "resizeHackObject",
-        type: "text/html" });
-      var klass = (0, _classnames2.default)("split-panel", this.props.direction, {
-        "split-panel-resizing": this.state.activeDividerIndex != -1
-      });
-      return _react2.default.createElement(
-        "div",
-        { ref: "self", className: klass },
-        resizeHackObject,
-        childrenWithDividers
-      );
-    }
-
-    //////
-    // Component Lifecycle
-    //////
-
-  }, {
-    key: "componentWillReceiveProps",
-    value: function componentWillReceiveProps(newProps) {
-      if (newProps.weights) {
-        var weights = this.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
-        // console.log("componentWillReceiveProps updating with weights: ", weights);
-        this.updateSizes(weights);
-      }
-    }
-  }, {
-    key: "componentDidMount",
-    value: function componentDidMount() {
-      var _this3 = this;
-
-      window.addEventListener("mouseup", this.onMouseUp);
-      window.addEventListener("mousemove", this.onMouseMove);
-      // We do this here because we can't guarantee that the event handler will be
-      // added before data is assigned if we do it in the JSX.
-      this.refs.resizeHackObject.addEventListener("load", function () {
-        return _this3.onResizeHackObjectLoad();
-      });
-      this.refs.resizeHackObject.data = "about:blank";
-      this.updateSizes();
-    }
-  }, {
-    key: "componentWillUnmount",
-    value: function componentWillUnmount() {
-      window.removeEventListener("mouseup", this.onMouseUp);
-      window.removeEventListener("mousemove", this.onMouseMove);
-    }
-
-    //////
-    // Properties
-    //////
-    /**
-     * Gets the weights for each panel. This prefers this.props.weights, falling
-     * through to this.state.weights then this.props.defaultWeights.
-     *
-     * An Error is thrown if no weights are specified.
-     */
-
-  }, {
-    key: "onResizeHackObjectLoad",
-
-
-    //////
-    // Event Handlers
-    //////
-    value: function onResizeHackObjectLoad() {
-      var _this4 = this;
-
-      this.refs.resizeHackObject.contentDocument.defaultView.addEventListener("resize", function () {
-        return _this4.updateSizes();
-      });
-    }
-  }, {
-    key: "onDividerMouseDown",
-    value: function onDividerMouseDown(e, dividerIndex) {
-      var newState = {
-        activeDividerIndex: dividerIndex,
-        lastCursorPosition: e[this.cursorPositionProperty]
-      };
-      this.setState(newState);
-    }
-  }, {
-    key: "onMouseUp",
-    value: function onMouseUp() {
-      //Adjust any messed up state at this point
-      //So they can drag around as much as they want, and state will get out of whack
-      //But as soon as they let go it'll fix itself
-      var mouseIsDown = this.state.activeDividerIndex !== -1;
-      var weights = this.weights;
-      if (mouseIsDown && this.doAdjustmentOnMouseUp && weights) {
-        var adjustedWeights = this.adjust(weights);
-        this.emitWeightChange(adjustedWeights);
-      }
-
-      this.setState({ activeDividerIndex: -1 });
-    }
-  }, {
-    key: "onMouseMove",
-    value: function onMouseMove(e) {
-      if (this.state.activeDividerIndex == -1) return;
-      // If moving backwards (left or up) grow the next panel by taking space
-      // from the previous one. If moving forwards (right or down) grow the
-      // previous panel by taking space from the next.
-      //
-      // Horizontal: <previous>|<next>
-      // Vertical:
-      //  <previous>
-      //  ----------
-      //  <next>
-      var prevIndex = this.state.activeDividerIndex;
-      var nextIndex = prevIndex + 1;
-      // First obtain the size difference, rounding it down to a multiple of
-      // the step size...
-      var diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
-      var steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
-      if (steppedDiff == 0) {
-        // No change.
-        return;
-      }
-      // ...then make it proportional to the total weight rather than the
-      // container size.
-      var weights = this.weights;
-      var weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _lodash2.default.sum(weights);
-
-      // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
-      var weightPrev = weights[prevIndex];
-      var weightNext = weights[nextIndex];
-      var minWeight = this.pxToWeight(weights, this.props.minPanelSize);
-
-      function weightViolated(weight, minWeight, directionIsWrong) {
-        return weight <= minWeight && directionIsWrong;
-      }
-
-      //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
-      var prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
-
-      //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
-      var nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
-
-      // console.log("prevWeightViolated", prevWeightViolated);
-      // console.log("nextWeightViolated", nextWeightViolated);
-
-      if (this.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
-        return;
-      }
-
-      // If weightDiff is negative we're moving backwards, so this will shrink
-      // <previous> and grow <next>. Otherwise, we're moving forwards and
-      // <previous> will grow while <next> shrinks.
-      weights[prevIndex] += weightDiff;
-      weights[nextIndex] -= weightDiff;
-
-      if (this.doAdjustmentOnMouseMove) {
-        var adjustedWeights = this.adjust(weights);
-        this.emitWeightChange(adjustedWeights);
-      } else {
-        this.emitWeightChange(weights);
-      }
-      var newState = {
-        // We subtract the portion of the difference that we discarded to avoid
-        // accumulating rounding errors resulting in the cursor and divider
-        // positions drifting apart.
-        lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
-      };
-      this.setState(newState);
-    }
-
-    //////
-    // Event Emitters
-    //////
-
-  }, {
-    key: "emitWeightChange",
-    value: function emitWeightChange(newWeights) {
-      var _this5 = this;
-
-      // Only set weights on the state if we don't expect the parent to
-      // accept/reject the new weights by updating this.props.weights.
-      if (this.props.defaultWeights && this.props.defaultWeights.length) {
-        this.setState({ weights: newWeights }, function () {
-          return _this5.updateSizes();
-        });
-      }
-      // Notify the parent that we'd like to change the weights.
-      if (this.props.onWeightChange) {
-        this.props.onWeightChange(newWeights);
-      }
-    }
-
-    //////
-    // Utilities
-    //////
-
-
-    /**
-     * Caution, mutating params
-     *
-     * @param sizes
-     * @param adjustmentNeeded
-     */
-
-  }, {
-    key: "adjustMaxDown",
-    value: function adjustMaxDown(sizes, adjustmentNeeded) {
-      var maxIndex = 0;
-      var maxPanelSize = sizes[0];
-      for (var i = 0; i < sizes.length; i++) {
-        if (sizes[i] > maxPanelSize) {
-          maxPanelSize = sizes[i];
-          maxIndex = i;
+    }, {
+        key: "componentWillReceiveProps",
+        value: function componentWillReceiveProps(newProps) {
+            if (newProps.weights) {
+                var weights = this.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
+                // console.log("componentWillReceiveProps updating with weights: ", weights);
+                this.updateSizes(weights);
+            }
         }
-      }
-      sizes[maxIndex] -= adjustmentNeeded;
-    }
-  }, {
-    key: "adjustMinUp",
-    value: function adjustMinUp(sizes, adjustmentNeeded) {
-      var minIndex = 0;
-      var minPanelSize = sizes[0];
-      for (var i = 0; i < sizes.length; i++) {
-        if (sizes[i] < minPanelSize) {
-          minPanelSize = sizes[i];
-          minIndex = i;
+    }, {
+        key: "componentDidMount",
+        value: function componentDidMount() {
+            var _this3 = this;
+
+            window.addEventListener("mouseup", this.onMouseUp);
+            window.addEventListener("mousemove", this.onMouseMove);
+            // We do this here because we can't guarantee that the event handler will be
+            // added before data is assigned if we do it in the JSX.
+            this.refs.resizeHackObject.addEventListener("load", function () {
+                return _this3.onResizeHackObjectLoad();
+            });
+            this.refs.resizeHackObject.data = "about:blank";
+            this.updateSizes();
         }
-      }
-      sizes[minIndex] += adjustmentNeeded;
-    }
-  }, {
-    key: "adjust",
-    value: function adjust(weights) {
-      //correct for sizes that got too big or too small
-      var sizesAndOffsets = this.calcSizesAndOffsets(weights);
-      var sizes = sizesAndOffsets.sizes;
-      var offsets = sizesAndOffsets.offsets;
-      var sumOfSizes = _lodash2.default.sum(sizes);
-      var domContainerSize = this.refs.self[this.domSizeProperty];
-      var expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
-      var diff = sumOfSizes - expectedSumOfSizes;
+    }, {
+        key: "componentWillUnmount",
+        value: function componentWillUnmount() {
+            window.removeEventListener("mouseup", this.onMouseUp);
+            window.removeEventListener("mousemove", this.onMouseMove);
+        }
 
-      if (diff > 0) {
-        // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
-        this.adjustMaxDown(sizes, diff);
-        return _lodash2.default.map(sizes, function (size) {
-          return size / expectedSumOfSizes * 100;
-        });
-      } else if (diff < 0) {
-        var absDiff = -diff;
-        // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
-        this.adjustMinUp(sizes, absDiff);
-        return _lodash2.default.map(sizes, function (size) {
-          return size / expectedSumOfSizes * 100;
-        });
-      }
+        //////
+        // Properties
+        //////
+        /**
+         * Gets the weights for each panel. This prefers this.props.weights, falling
+         * through to this.state.weights then this.props.defaultWeights.
+         *
+         * An Error is thrown if no weights are specified.
+         */
 
-      return weights;
-    }
-  }, {
-    key: "weightToPx",
-    value: function weightToPx(weights, index) {
-      var totalWeight = _lodash2.default.sum(weights);
-      // Total space taken by the dividers spread equally across all panels.
-      var dividerCompensation = this.dividerSize * (weights.length - 1) / weights.length;
-      var proportion = weights[index] / totalWeight;
-      return proportion * this.refs.self[this.domSizeProperty] - dividerCompensation;
-    }
-  }, {
-    key: "pxToWeight",
-    value: function pxToWeight(weights, pixels) {
-      // Total space taken by the dividers spread equally across all panels.
-      var dividerCompensation = this.dividerSize * (weights.length - 1) / weights.length;
-      return 100 * ((pixels + dividerCompensation) / this.refs.self[this.domSizeProperty]);
-    }
-  }, {
-    key: "calcSizesAndOffsets",
-    value: function calcSizesAndOffsets(weights, children) {
-      // console.log("calcSizesAndOffsets");
-      // console.log("weights", weights);
-      // console.log("children", children);
-      weights = weights || this.weights;
-      weights = this.padOrTruncateWeights(weights, children);
-      var totalWeight = _lodash2.default.sum(weights);
-      // Total space taken by the dividers spread equally across all panels.
-      var dividerCompensation = this.dividerSize * (weights.length - 1) / weights.length;
-      var offsets = [];
-      var sizes = [];
-      for (var i = 0; i < weights.length; i++) {
-        //TODO fix the math here, offsets start to be further and further off as the number of panes grows
-        offsets.push(_lodash2.default.sum(sizes) + 2 * dividerCompensation * i);
-        var sizeInPx = this.weightToPx(weights, i);
-        sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
-      }
-      return { sizes: sizes, offsets: offsets };
-    }
+    }, {
+        key: "onResizeHackObjectLoad",
 
-    /**
-     * Recalculates the size of each panel according to the weights, taking into
-     * account the space used by the dividers then updates this.state.sizes
-     * and this.state.offsets.
-     */
 
-  }, {
-    key: "updateSizes",
-    value: function updateSizes(weights, children) {
-      // console.log("updateSizes");
-      // console.log("weights", weights);
-      // console.log("children", children);
-      var sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
-      this.setState(sizesAndOffsets);
-    }
+        //////
+        // Event Handlers
+        //////
+        value: function onResizeHackObjectLoad() {
+            var _this4 = this;
 
-    /**
-     * Caution, mutating params
-     *
-     * @param weights
-     * @returns {*}
-     */
+            this.refs.resizeHackObject.contentDocument.defaultView.addEventListener("resize", function () {
+                return _this4.updateSizes();
+            });
+        }
+    }, {
+        key: "onDividerMouseDown",
+        value: function onDividerMouseDown(e, dividerIndex) {
+            var newState = {
+                activeDividerIndex: dividerIndex,
+                lastCursorPosition: e[this.cursorPositionProperty]
+            };
+            this.setState(newState);
+        }
+    }, {
+        key: "onMouseUp",
+        value: function onMouseUp() {
+            //Adjust any messed up state at this point
+            //So they can drag around as much as they want, and state will get out of whack
+            //But as soon as they let go it'll fix itself
+            var mouseIsDown = this.state.activeDividerIndex !== -1;
+            var weights = this.weights;
+            if (mouseIsDown && this.doAdjustmentOnMouseUp && weights) {
+                var adjustedWeights = this.adjust(weights);
+                this.emitWeightChange(adjustedWeights);
+            }
 
-  }, {
-    key: "padOrTruncateWeights",
-    value: function padOrTruncateWeights(weights) {
-      var children = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.children;
+            this.setState({ activeDividerIndex: -1 });
+        }
+    }, {
+        key: "onMouseMove",
+        value: function onMouseMove(e) {
+            if (this.state.activeDividerIndex == -1) return;
+            // If moving backwards (left or up) grow the next panel by taking space
+            // from the previous one. If moving forwards (right or down) grow the
+            // previous panel by taking space from the next.
+            //
+            // Horizontal: <previous>|<next>
+            // Vertical:
+            //  <previous>
+            //  ----------
+            //  <next>
+            var prevIndex = this.state.activeDividerIndex;
+            var nextIndex = prevIndex + 1;
+            // First obtain the size difference, rounding it down to a multiple of
+            // the step size...
+            var diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
+            var steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
+            if (steppedDiff == 0) {
+                // No change.
+                return;
+            }
+            // ...then make it proportional to the total weight rather than the
+            // container size.
+            var weights = this.weights;
+            var weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _lodash2.default.sum(weights);
 
-      return weights;
-      // console.log("padOrTruncateWeights");
-      // console.log("weights", weights);
-      // console.log("children", children);
-      // const numChildren = React.Children.count(children);
-      // if (weights.length < numChildren) {
-      //   const min = Math.max(_.min(weights), this.props.minPanelSize);
-      //   console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
-      //     `but there are ${numChildren} subpanels; using ${min} for the ` +
-      //     `remaining subpanels`);
-      //   while (weights.length < numChildren) {
-      //     weights.push(min);
-      //   }
-      // }
-      // else if (weights.length > numChildren) {
-      //   console.warn(`SplitPanel: ${weights.length} weights specified but ` +
-      //     `there are only ${numChildren} subpanels; ignoring additional weights`);
-      //   weights = weights.splice(0, numChildren);
-      // }
-      // return weights;
-    }
-  }, {
-    key: "weights",
-    get: function get() {
-      var weights = null;
-      if (this.props.weights && this.props.weights.length) {
-        weights = this.props.weights;
-      } else if (this.state.weights && this.state.weights.length) {
-        weights = this.state.weights;
-      } else if (this.props.defaultWeights && this.props.defaultWeights.length) {
-        weights = this.props.defaultWeights;
-      } else {
-        throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
-      }
-      return this.padOrTruncateWeights(weights);
-    }
-  }, {
-    key: "cursorPositionProperty",
-    get: function get() {
-      return this.props.direction == "horizontal" ? "clientX" : "clientY";
-    }
-  }, {
-    key: "cssSizeProperty",
-    get: function get() {
-      return this.props.direction == "horizontal" ? "width" : "height";
-    }
-  }, {
-    key: "cssOffsetProperty",
-    get: function get() {
-      return this.props.direction == "horizontal" ? "left" : "top";
-    }
-  }, {
-    key: "domSizeProperty",
-    get: function get() {
-      return this.props.direction == "horizontal" ? "clientWidth" : "clientHeight";
-    }
-  }, {
-    key: "dividerSize",
-    get: function get() {
-      // During the initial render we can't calculate this, so default to 5px.
-      // A fresh render is forced after the component is mounted to it doesn't
-      // matter.
-      if (this.refs["divider-0"]) {
-        return this.refs["divider-0"][this.domSizeProperty];
-      } else {
-        return 5;
-      }
-    }
-  }, {
-    key: "sizes",
-    get: function get() {
-      var numChildren = _react2.default.Children.count(this.props.children);
-      if (this.state.sizes.length == numChildren) {
-        return this.state.sizes;
-      } else {
-        // XXX: We can't calculate the sizes until the component has been rendered
-        // at least once (so we can't just call this.updateSizes() here) because
-        // we need to obtain the divider size from the DOM.
-        // Instead we say that all the panels are at the minimum size and hope
-        // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
-        // this is.
-        return _lodash2.default.fill(new Array(numChildren), this.props.minPanelSize);
-      }
-    }
-  }, {
-    key: "offsets",
-    get: function get() {
-      var numChildren = _react2.default.Children.count(this.props.children);
-      if (this.state.offsets.length == numChildren) {
-        return this.state.offsets;
-      } else {
-        // See the comment in `get sizes()`. The same applies here.
-        return _lodash2.default.fill(new Array(numChildren), 0);
-      }
-    }
-  }]);
+            // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
+            var weightPrev = weights[prevIndex];
+            var weightNext = weights[nextIndex];
+            var minWeight = this.pxToWeight(weights, this.props.minPanelSize);
 
-  return SplitPanel;
+            function weightViolated(weight, minWeight, directionIsWrong) {
+                return weight <= minWeight && directionIsWrong;
+            }
+
+            //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
+            var prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
+
+            //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
+            var nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
+
+            // console.log("prevWeightViolated", prevWeightViolated);
+            // console.log("nextWeightViolated", nextWeightViolated);
+
+            if (this.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
+                return;
+            }
+
+            // If weightDiff is negative we're moving backwards, so this will shrink
+            // <previous> and grow <next>. Otherwise, we're moving forwards and
+            // <previous> will grow while <next> shrinks.
+            weights[prevIndex] += weightDiff;
+            weights[nextIndex] -= weightDiff;
+
+            if (this.doAdjustmentOnMouseMove) {
+                var adjustedWeights = this.adjust(weights);
+                this.emitWeightChange(adjustedWeights);
+            } else {
+                this.emitWeightChange(weights);
+            }
+            var newState = {
+                // We subtract the portion of the difference that we discarded to avoid
+                // accumulating rounding errors resulting in the cursor and divider
+                // positions drifting apart.
+                lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
+            };
+            this.setState(newState);
+        }
+
+        //////
+        // Event Emitters
+        //////
+
+    }, {
+        key: "emitWeightChange",
+        value: function emitWeightChange(newWeights) {
+            var _this5 = this;
+
+            // Only set weights on the state if we don't expect the parent to
+            // accept/reject the new weights by updating this.props.weights.
+            if (this.props.defaultWeights && this.props.defaultWeights.length) {
+                this.setState({ weights: newWeights }, function () {
+                    return _this5.updateSizes();
+                });
+            }
+            // Notify the parent that we'd like to change the weights.
+            if (this.props.onWeightChange) {
+                this.props.onWeightChange(newWeights);
+            }
+        }
+
+        //////
+        // Utilities
+        //////
+
+
+        /**
+         * Caution, mutating params
+         *
+         * @param sizes
+         * @param adjustmentNeeded
+         */
+
+    }, {
+        key: "adjustMaxDown",
+        value: function adjustMaxDown(sizes, adjustmentNeeded) {
+            var maxIndex = 0;
+            var maxPanelSize = sizes[0];
+            for (var i = 0; i < sizes.length; i++) {
+                if (sizes[i] > maxPanelSize) {
+                    maxPanelSize = sizes[i];
+                    maxIndex = i;
+                }
+            }
+            sizes[maxIndex] -= adjustmentNeeded;
+        }
+    }, {
+        key: "adjustMinUp",
+        value: function adjustMinUp(sizes, adjustmentNeeded) {
+            var minIndex = 0;
+            var minPanelSize = sizes[0];
+            for (var i = 0; i < sizes.length; i++) {
+                if (sizes[i] < minPanelSize) {
+                    minPanelSize = sizes[i];
+                    minIndex = i;
+                }
+            }
+            sizes[minIndex] += adjustmentNeeded;
+        }
+    }, {
+        key: "adjust",
+        value: function adjust(weights) {
+            //correct for sizes that got too big or too small
+            var sizesAndOffsets = this.calcSizesAndOffsets(weights);
+            var sizes = sizesAndOffsets.sizes;
+            // const offsets = sizesAndOffsets.offsets;
+            var sumOfSizes = _lodash2.default.sum(sizes);
+            var domContainerSize = this.refs.self[this.domSizeProperty];
+            var expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
+            var diff = sumOfSizes - expectedSumOfSizes;
+
+            if (diff > 0) {
+                // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
+                this.adjustMaxDown(sizes, diff);
+                return _lodash2.default.map(sizes, function (size) {
+                    return size / expectedSumOfSizes * 100;
+                });
+            } else if (diff < 0) {
+                var absDiff = -diff;
+                // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
+                this.adjustMinUp(sizes, absDiff);
+                return _lodash2.default.map(sizes, function (size) {
+                    return size / expectedSumOfSizes * 100;
+                });
+            }
+
+            return weights;
+        }
+
+        /**
+         * Return the amount of pixels this panel should take up
+         * Take into account the number of weights, and the space that the dividers take up
+         *
+         * Example
+         *   There are 4 weights, and the current one is 27%
+         *   The container is 1000px, and the dividers are 5px
+         *   4 weights means 3 dividers. The total space they take up is then 15px
+         *   The total amount of pixels that the panels themselves can take up is 1000px - 15px = 985px
+         *   27% of 985px is 265.95px
+         *
+         * @param weights
+         * @param index
+         * @returns {number}
+         */
+
+    }, {
+        key: "weightToPx",
+        value: function weightToPx(weights, index) {
+            // Should always be 100, todo consider validating here
+            var totalWeight = _lodash2.default.sum(weights);
+
+            // The current weight's proportion of the entire container (so 27% becomes 0.27)
+            var proportion = weights[index] / totalWeight;
+
+            var totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+            var spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+            return proportion * spaceLeftForPanels;
+        }
+
+        /**
+         * Return the weight that this amount of pixels corresponds to
+         *
+         * @param weights
+         * @param pixels
+         * @returns {number}
+         */
+
+    }, {
+        key: "pxToWeight",
+        value: function pxToWeight(weights, pixels) {
+            var totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+            var spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+            return 100 * pixels / spaceLeftForPanels;
+        }
+    }, {
+        key: "calcSizesAndOffsets",
+        value: function calcSizesAndOffsets(weights, children) {
+            weights = weights || this.weights;
+            weights = this.padOrTruncateWeights(weights, children);
+            var offsets = [];
+            var sizes = [];
+            for (var i = 0; i < weights.length; i++) {
+                var totalDividerSizeSoFar = i * this.dividerSize;
+                var sizeInPx = this.weightToPx(weights, i);
+                offsets.push(i === 0 ? 0 : _lodash2.default.sum(sizes) + totalDividerSizeSoFar);
+                sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
+            }
+            return { sizes: sizes, offsets: offsets };
+        }
+
+        /**
+         * Recalculates the size of each panel according to the weights, taking into
+         * account the space used by the dividers then updates this.state.sizes
+         * and this.state.offsets.
+         */
+
+    }, {
+        key: "updateSizes",
+        value: function updateSizes(weights, children) {
+            var sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
+            this.setState(sizesAndOffsets);
+        }
+
+        /**
+         * Caution, mutating params
+         *
+         * @param weights
+         * @returns {*}
+         */
+
+    }, {
+        key: "padOrTruncateWeights",
+        value: function padOrTruncateWeights(weights) {
+            var children = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.children;
+
+            return weights;
+            // console.log("padOrTruncateWeights");
+            // console.log("weights", weights);
+            // console.log("children", children);
+            // const numChildren = React.Children.count(children);
+            // if (weights.length < numChildren) {
+            //   const min = Math.max(_.min(weights), this.props.minPanelSize);
+            //   console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
+            //     `but there are ${numChildren} subpanels; using ${min} for the ` +
+            //     `remaining subpanels`);
+            //   while (weights.length < numChildren) {
+            //     weights.push(min);
+            //   }
+            // }
+            // else if (weights.length > numChildren) {
+            //   console.warn(`SplitPanel: ${weights.length} weights specified but ` +
+            //     `there are only ${numChildren} subpanels; ignoring additional weights`);
+            //   weights = weights.splice(0, numChildren);
+            // }
+            // return weights;
+        }
+    }, {
+        key: "weights",
+        get: function get() {
+            var weights = null;
+            if (this.props.weights && this.props.weights.length) {
+                weights = this.props.weights;
+            } else if (this.state.weights && this.state.weights.length) {
+                weights = this.state.weights;
+            } else if (this.props.defaultWeights && this.props.defaultWeights.length) {
+                weights = this.props.defaultWeights;
+            } else {
+                throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
+            }
+            return this.padOrTruncateWeights(weights);
+        }
+    }, {
+        key: "cursorPositionProperty",
+        get: function get() {
+            return this.props.direction == "horizontal" ? "clientX" : "clientY";
+        }
+    }, {
+        key: "cssSizeProperty",
+        get: function get() {
+            return this.props.direction == "horizontal" ? "width" : "height";
+        }
+    }, {
+        key: "cssOffsetProperty",
+        get: function get() {
+            return this.props.direction == "horizontal" ? "left" : "top";
+        }
+    }, {
+        key: "domSizeProperty",
+        get: function get() {
+            return this.props.direction == "horizontal" ? "clientWidth" : "clientHeight";
+        }
+    }, {
+        key: "dividerSize",
+        get: function get() {
+            // During the initial render we can't calculate this, so default to 5px.
+            // A fresh render is forced after the component is mounted to it doesn't
+            // matter.
+            if (this.refs["divider-0"]) {
+                return this.refs["divider-0"][this.domSizeProperty];
+            } else {
+                return 5;
+            }
+        }
+    }, {
+        key: "sizes",
+        get: function get() {
+            var numChildren = _react2.default.Children.count(this.props.children);
+            if (this.state.sizes.length == numChildren) {
+                return this.state.sizes;
+            } else {
+                // XXX: We can't calculate the sizes until the component has been rendered
+                // at least once (so we can't just call this.updateSizes() here) because
+                // we need to obtain the divider size from the DOM.
+                // Instead we say that all the panels are at the minimum size and hope
+                // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
+                // this is.
+                return _lodash2.default.fill(new Array(numChildren), this.props.minPanelSize);
+            }
+        }
+    }, {
+        key: "offsets",
+        get: function get() {
+            var numChildren = _react2.default.Children.count(this.props.children);
+            if (this.state.offsets.length == numChildren) {
+                return this.state.offsets;
+            } else {
+                // See the comment in `get sizes()`. The same applies here.
+                return _lodash2.default.fill(new Array(numChildren), 0);
+            }
+        }
+    }]);
+
+    return SplitPanel;
 }(_react2.default.Component);
 
 SplitPanel.propTypes = {
-  /**
-   * The direction to layout subpanels. One of "horizontal" or "vertical".
-   *
-   * Default: horizontal
-   */
-  direction: _react2.default.PropTypes.oneOf(["horizontal", "vertical"]),
+    /**
+     * The direction to layout subpanels. One of "horizontal" or "vertical".
+     *
+     * Default: horizontal
+     */
+    direction: _react2.default.PropTypes.oneOf(["horizontal", "vertical"]),
 
-  /**
-   * The minimum size (in pixels) of a subpanel. The divider will stop
-   * abruptly if the user attempts to shrink a subpanel below this size.
-   *
-   * Default: 25
-   */
-  minPanelSize: _react2.default.PropTypes.number,
+    /**
+     * The minimum size (in pixels) of a subpanel. The divider will stop
+     * abruptly if the user attempts to shrink a subpanel below this size.
+     *
+     * Default: 25
+     */
+    minPanelSize: _react2.default.PropTypes.number,
 
-  /**
-   * Called whenever a subpanel is resized.
-   *
-   * You should update `weights` in response to this event unless you're
-   * using `defaultWeights`.
-   */
-  onWeightChange: _react2.default.PropTypes.func,
+    /**
+     * Called whenever a subpanel is resized.
+     *
+     * You should update `weights` in response to this event unless you're
+     * using `defaultWeights`.
+     */
+    onWeightChange: _react2.default.PropTypes.func,
 
-  /**
-   * The weights of each subpanel. If you're using this property you must
-   * manually update this prop in response to `onWeightChange` otherwise
-   * the subpanels will not resize.
-   */
-  weights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
+    /**
+     * The weights of each subpanel. If you're using this property you must
+     * manually update this prop in response to `onWeightChange` otherwise
+     * the subpanels will not resize.
+     */
+    weights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
 
-  /**
-   * The default weights to use when you are not managing the weights
-   * manually via the `weights` and `onWeightChange` props.
-   */
-  defaultWeights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
+    /**
+     * The default weights to use when you are not managing the weights
+     * manually via the `weights` and `onWeightChange` props.
+     */
+    defaultWeights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
 
-  /**
-   * The resize step size in pixels.
-   *
-   * Useful if you have monospaced text and you want to ensure the panel
-   * is resized in increments of one character width.
-   *
-   * Default: 1
-   */
-  stepSize: _react2.default.PropTypes.number
+    /**
+     * The resize step size in pixels.
+     *
+     * Useful if you have monospaced text and you want to ensure the panel
+     * is resized in increments of one character width.
+     *
+     * Default: 1
+     */
+    stepSize: _react2.default.PropTypes.number
 };
 SplitPanel.defaultProps = {
-  direction: "horizontal",
-  minPanelSize: 25,
-  stepSize: 1
+    direction: "horizontal",
+    minPanelSize: 25,
+    stepSize: 1
 };
 exports.default = SplitPanel;

--- a/dist/SplitPanel.js
+++ b/dist/SplitPanel.js
@@ -73,10 +73,6 @@ var SplitPanel = function (_React$Component) {
         // componentWillUnmount.
         _this.onMouseMove = _this.onMouseMove.bind(_this);
         _this.onMouseUp = _this.onMouseUp.bind(_this);
-        _this.doAdjustmentOnMouseUp = true;
-        _this.exitMouseMoveOnViolation = true;
-        _this.adjustOnReceiveProps = true;
-        _this.doAdjustmentOnMouseMove = false; //Not recommended, seems to cause incorrect results
         return _this;
     }
 
@@ -145,7 +141,7 @@ var SplitPanel = function (_React$Component) {
         key: "componentWillReceiveProps",
         value: function componentWillReceiveProps(newProps) {
             if (newProps.weights) {
-                var weights = this.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
+                var weights = this.props.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
                 // console.log("componentWillReceiveProps updating with weights: ", weights);
                 this.updateSizes(weights);
             }
@@ -213,7 +209,7 @@ var SplitPanel = function (_React$Component) {
             //But as soon as they let go it'll fix itself
             var mouseIsDown = this.state.activeDividerIndex !== -1;
             var weights = this.weights;
-            if (mouseIsDown && this.doAdjustmentOnMouseUp && weights) {
+            if (mouseIsDown && this.props.doAdjustmentOnMouseUp && weights) {
                 var adjustedWeights = this.adjust(weights);
                 this.emitWeightChange(adjustedWeights);
             }
@@ -266,7 +262,7 @@ var SplitPanel = function (_React$Component) {
             // console.log("prevWeightViolated", prevWeightViolated);
             // console.log("nextWeightViolated", nextWeightViolated);
 
-            if (this.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
+            if (this.props.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
                 return;
             }
 
@@ -276,7 +272,7 @@ var SplitPanel = function (_React$Component) {
             weights[prevIndex] += weightDiff;
             weights[nextIndex] -= weightDiff;
 
-            if (this.doAdjustmentOnMouseMove) {
+            if (this.props.doAdjustmentOnMouseMove) {
                 var adjustedWeights = this.adjust(weights);
                 this.emitWeightChange(adjustedWeights);
             } else {
@@ -456,6 +452,7 @@ var SplitPanel = function (_React$Component) {
         key: "updateSizes",
         value: function updateSizes(weights, children) {
             var sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
+            // console.log("sizesAndOffsets", sizesAndOffsets);
             this.setState(sizesAndOffsets);
         }
 
@@ -616,11 +613,56 @@ SplitPanel.propTypes = {
      *
      * Default: 1
      */
-    stepSize: _react2.default.PropTypes.number
+    stepSize: _react2.default.PropTypes.number,
+
+    /**
+     * Bool that controls adjustment on mouse up functionality
+     *
+     * Used to adjust the weights after a fast mousemove by the user
+     * Without it they may start to exceed the dimensions of the container
+     *
+     * Default: true
+     */
+    doAdjustmentOnMouseUp: _react2.default.PropTypes.bool,
+
+    /**
+     * Bool that controls exit on violation during mouse move functionality
+     *
+     * During the mouse move, if the minPanelSize is violated,
+     * Don't go through with the state change
+     *
+     * Default: true
+     */
+    exitMouseMoveOnViolation: _react2.default.PropTypes.bool,
+
+    /**
+     * Bool that controls adjustment on componentWillReceiveProps
+     *
+     * Used to adjust the weights when getting new props
+     *
+     * Default: true
+     */
+    adjustOnReceiveProps: _react2.default.PropTypes.bool,
+
+    /**
+     * Bool that controls adjustment on mouse move functionality
+     *
+     * Used to adjust the weights during a fast mousemove by the user
+     * Without it they may start to exceed the dimensions of the container
+     * This one is a bit risky since the action is in the middle of happening
+     * Optional and not recommended unless you're getting better results with it
+     *
+     * Default: false
+     */
+    doAdjustmentOnMouseMove: _react2.default.PropTypes.bool
 };
 SplitPanel.defaultProps = {
     direction: "horizontal",
     minPanelSize: 25,
-    stepSize: 1
+    stepSize: 1,
+    doAdjustmentOnMouseUp: true,
+    exitMouseMoveOnViolation: true,
+    adjustOnReceiveProps: true,
+    doAdjustmentOnMouseMove: false
 };
 exports.default = SplitPanel;

--- a/dist/SplitPanel.js
+++ b/dist/SplitPanel.js
@@ -1,7 +1,7 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -43,626 +43,653 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
  * used for all remaining elements. Any additional weights will be ignored.
  */
 var SplitPanel = function (_React$Component) {
-    _inherits(SplitPanel, _React$Component);
+  _inherits(SplitPanel, _React$Component);
 
-    function SplitPanel() {
-        _classCallCheck(this, SplitPanel);
+  function SplitPanel() {
+    _classCallCheck(this, SplitPanel);
 
-        var _this = _possibleConstructorReturn(this, (SplitPanel.__proto__ || Object.getPrototypeOf(SplitPanel)).call(this));
+    var _this = _possibleConstructorReturn(this, (SplitPanel.__proto__ || Object.getPrototypeOf(SplitPanel)).call(this));
 
-        _this.state = {
-            // The last position of the cursor. Used by onMouseMove to calculate
-            // relative changes in divider position.
-            lastCursorPosition: 0,
-            // Sizes of the subpanels taking into account the weights and divider
-            // size.
-            sizes: [],
-            // Offsets of each subpanel.
-            offsets: [],
-            // The index of the divider currently being dragged by the user.
-            activeDividerIndex: -1
-        };
+    _this.state = {
+      // The last position of the cursor. Used by onMouseMove to calculate
+      // relative changes in divider position.
+      lastCursorPosition: 0,
+      // Sizes of the subpanels taking into account the weights and divider
+      // size.
+      sizes: [],
+      // Offsets of each subpanel.
+      offsets: [],
+      // The index of the divider currently being dragged by the user.
+      activeDividerIndex: -1
+    };
 
-        // Bind event listeners in advance.
-        _this.onDividerMouseDown = _this.onDividerMouseDown.bind(_this);
-        // These two are attached to `window` because sometimes due to glitches we
-        // can't do very much about we'll be unable to move the divider in time to
-        // keep up with the mouse cursor, but we still need to move the divider to
-        // catch up and to release it when the user releases the divider.
-        // N.B. These are attached in componentDidMount and detached in
-        // componentWillUnmount.
-        _this.onMouseMove = _this.onMouseMove.bind(_this);
-        _this.onMouseUp = _this.onMouseUp.bind(_this);
-        return _this;
+    // Bind event listeners in advance.
+    _this.onDividerMouseDown = _this.onDividerMouseDown.bind(_this);
+    // These two are attached to `window` because sometimes due to glitches we
+    // can't do very much about we'll be unable to move the divider in time to
+    // keep up with the mouse cursor, but we still need to move the divider to
+    // catch up and to release it when the user releases the divider.
+    // N.B. These are attached in componentDidMount and detached in
+    // componentWillUnmount.
+    _this.onMouseMove = _this.onMouseMove.bind(_this);
+    _this.onMouseUp = _this.onMouseUp.bind(_this);
+    return _this;
+  }
+
+  _createClass(SplitPanel, [{
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      // Create a sized splitPanelItem with a divider for each child, except...
+      var childrenWithDividers = [];
+      var children = _react2.default.Children.toArray(this.props.children);
+
+      var _loop = function _loop(i) {
+        var _style;
+
+        var style = (_style = {}, _defineProperty(_style, _this2.cssSizeProperty, _this2.sizes[i]), _defineProperty(_style, _this2.cssOffsetProperty, _this2.offsets[i]), _style);
+
+        childrenWithDividers.push(_react2.default.createElement(
+          "div",
+          { key: "panel-" + i,
+            className: "split-panel-item",
+            style: style },
+          children[i]
+        ));
+
+        // ...don't add a divider if it's the last panel.
+        if (i < children.length - 1) {
+          var dividerStyle = _defineProperty({}, _this2.cssOffsetProperty, _this2.offsets[i + 1] - _this2.dividerSize);
+          childrenWithDividers.push(_react2.default.createElement("div", {
+            key: "divider-" + i, ref: "divider-" + i,
+            className: "split-panel-divider",
+            style: dividerStyle,
+            onMouseDown: function onMouseDown(e) {
+              return _this2.onDividerMouseDown(e, i);
+            } }));
+        }
+      };
+
+      for (var i = 0; i < children.length; i++) {
+        _loop(i);
+      }
+
+      // Because elements don't have a resize event we create an <object> with
+      // no content and filling the entire panel. When this object's
+      // contentDocument.resize event fires we know to update the sizes of all
+      // the subpanels. :-)
+      var resizeHackObject = _react2.default.createElement("object", { className: "split-panel-resize-hack-object",
+        ref: "resizeHackObject",
+        type: "text/html" });
+      var klass = (0, _classnames2.default)("split-panel", this.props.direction, {
+        "split-panel-resizing": this.state.activeDividerIndex != -1
+      });
+      return _react2.default.createElement(
+        "div",
+        { ref: "self", className: klass },
+        resizeHackObject,
+        childrenWithDividers
+      );
     }
 
-    _createClass(SplitPanel, [{
-        key: "render",
-        value: function render() {
-            var _this2 = this;
+    //////
+    // Component Lifecycle
+    //////
 
-            // Create a sized splitPanelItem with a divider for each child, except...
-            var childrenWithDividers = [];
-            var children = _react2.default.Children.toArray(this.props.children);
+  }, {
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(newProps) {
+      //Make sure to call padOrTruncateWeights with the children from newProps,
+      //Otherwise it'll check the old children and won't render properly until re-sized
+      if (newProps.weights) {
+        var weights = this.padOrTruncateWeights(newProps.weights, newProps.children);
+        var adjustedWeights = this.props.adjustOnReceiveProps ? this.adjust(weights) : weights;
+        this.updateSizes(adjustedWeights);
+      }
+    }
+  }, {
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      var _this3 = this;
 
-            var _loop = function _loop(i) {
-                var _style;
+      window.addEventListener("mouseup", this.onMouseUp);
+      window.addEventListener("mousemove", this.onMouseMove);
+      // We do this here because we can't guarantee that the event handler will be
+      // added before data is assigned if we do it in the JSX.
+      this.refs.resizeHackObject.addEventListener("load", function () {
+        return _this3.onResizeHackObjectLoad();
+      });
+      this.refs.resizeHackObject.data = "about:blank";
+      this.updateSizes();
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      window.removeEventListener("mouseup", this.onMouseUp);
+      window.removeEventListener("mousemove", this.onMouseMove);
+    }
 
-                var style = (_style = {}, _defineProperty(_style, _this2.cssSizeProperty, _this2.sizes[i]), _defineProperty(_style, _this2.cssOffsetProperty, _this2.offsets[i]), _style);
+    //////
+    // Properties
+    //////
+    /**
+     * Gets the weights for each panel. This prefers this.props.weights, falling
+     * through to this.state.weights then this.props.defaultWeights.
+     *
+     * An Error is thrown if no weights are specified.
+     */
 
-                childrenWithDividers.push(_react2.default.createElement(
-                    "div",
-                    { key: "panel-" + i,
-                        className: "split-panel-item",
-                        style: style },
-                    children[i]
-                ));
+  }, {
+    key: "onResizeHackObjectLoad",
 
-                // ...don't add a divider if it's the last panel.
-                if (i < children.length - 1) {
-                    var dividerStyle = _defineProperty({}, _this2.cssOffsetProperty, _this2.offsets[i + 1] - _this2.dividerSize);
-                    childrenWithDividers.push(_react2.default.createElement("div", {
-                        key: "divider-" + i, ref: "divider-" + i,
-                        className: "split-panel-divider",
-                        style: dividerStyle,
-                        onMouseDown: function onMouseDown(e) {
-                            return _this2.onDividerMouseDown(e, i);
-                        } }));
-                }
-            };
 
-            for (var i = 0; i < children.length; i++) {
-                _loop(i);
-            }
+    //////
+    // Event Handlers
+    //////
+    value: function onResizeHackObjectLoad() {
+      var _this4 = this;
 
-            // Because elements don't have a resize event we create an <object> with
-            // no content and filling the entire panel. When this object's
-            // contentDocument.resize event fires we know to update the sizes of all
-            // the subpanels. :-)
-            var resizeHackObject = _react2.default.createElement("object", { className: "split-panel-resize-hack-object",
-                ref: "resizeHackObject",
-                type: "text/html" });
-            var klass = (0, _classnames2.default)("split-panel", this.props.direction, {
-                "split-panel-resizing": this.state.activeDividerIndex != -1
-            });
-            return _react2.default.createElement(
-                "div",
-                { ref: "self", className: klass },
-                resizeHackObject,
-                childrenWithDividers
-            );
+      this.refs.resizeHackObject.contentDocument.defaultView.addEventListener("resize", function () {
+        return _this4.updateSizes();
+      });
+    }
+  }, {
+    key: "onDividerMouseDown",
+    value: function onDividerMouseDown(e, dividerIndex) {
+      var newState = {
+        activeDividerIndex: dividerIndex,
+        lastCursorPosition: e[this.cursorPositionProperty]
+      };
+      this.setState(newState);
+    }
+  }, {
+    key: "onMouseUp",
+    value: function onMouseUp() {
+      //Adjust any messed up state at this point
+      //So they can drag around as much as they want, and state will get out of whack
+      //But as soon as they let go it'll fix itself
+      var mouseIsDown = this.state.activeDividerIndex !== -1;
+      var weights = this.weights;
+      if (mouseIsDown && this.props.doAdjustmentOnMouseUp && weights) {
+        var adjustedWeights = this.adjust(weights);
+        this.emitWeightChange(adjustedWeights);
+      }
+
+      this.setState({ activeDividerIndex: -1 });
+    }
+  }, {
+    key: "onMouseMove",
+    value: function onMouseMove(e) {
+      if (this.state.activeDividerIndex == -1) return;
+      // If moving backwards (left or up) grow the next panel by taking space
+      // from the previous one. If moving forwards (right or down) grow the
+      // previous panel by taking space from the next.
+      //
+      // Horizontal: <previous>|<next>
+      // Vertical:
+      //  <previous>
+      //  ----------
+      //  <next>
+      var prevIndex = this.state.activeDividerIndex;
+      var nextIndex = prevIndex + 1;
+      // First obtain the size difference, rounding it down to a multiple of
+      // the step size...
+      var diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
+      var steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
+      if (steppedDiff == 0) {
+        // No change.
+        return;
+      }
+      // ...then make it proportional to the total weight rather than the
+      // container size.
+      var weights = this.weights;
+      var weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _lodash2.default.sum(weights);
+
+      // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
+      var weightPrev = weights[prevIndex];
+      var weightNext = weights[nextIndex];
+      var minWeight = this.pxToWeight(weights, this.props.minPanelSize);
+
+      function weightViolated(weight, minWeight, directionIsWrong) {
+        return weight <= minWeight && directionIsWrong;
+      }
+
+      //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
+      var prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
+
+      //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
+      var nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
+
+      // console.log("prevWeightViolated", prevWeightViolated);
+      // console.log("nextWeightViolated", nextWeightViolated);
+
+      if (this.props.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
+        return;
+      }
+
+      // If weightDiff is negative we're moving backwards, so this will shrink
+      // <previous> and grow <next>. Otherwise, we're moving forwards and
+      // <previous> will grow while <next> shrinks.
+      weights[prevIndex] += weightDiff;
+      weights[nextIndex] -= weightDiff;
+
+      if (this.props.doAdjustmentOnMouseMove) {
+        var adjustedWeights = this.adjust(weights);
+        this.emitWeightChange(adjustedWeights);
+      } else {
+        this.emitWeightChange(weights);
+      }
+      var newState = {
+        // We subtract the portion of the difference that we discarded to avoid
+        // accumulating rounding errors resulting in the cursor and divider
+        // positions drifting apart.
+        lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
+      };
+      this.setState(newState);
+    }
+
+    //////
+    // Event Emitters
+    //////
+
+  }, {
+    key: "emitWeightChange",
+    value: function emitWeightChange(newWeights) {
+      var _this5 = this;
+
+      // Only set weights on the state if we don't expect the parent to
+      // accept/reject the new weights by updating this.props.weights.
+      if (this.props.defaultWeights && this.props.defaultWeights.length) {
+        this.setState({ weights: newWeights }, function () {
+          return _this5.updateSizes();
+        });
+      }
+      // Notify the parent that we'd like to change the weights.
+      if (this.props.onWeightChange) {
+        this.props.onWeightChange(newWeights);
+      }
+    }
+
+    //////
+    // Utilities
+    //////
+
+
+    /**
+     * Return a new array of sizes with the adjustment made
+     * The adjustment is to subtract adjustmentNeeded from the largest size in the array
+     *
+     * @param originalSizes
+     * @param adjustmentNeeded
+     */
+
+  }, {
+    key: "adjustMaxDown",
+    value: function adjustMaxDown(originalSizes, adjustmentNeeded) {
+      var sizes = _lodash2.default.clone(originalSizes);
+      var maxIndex = 0;
+      var maxPanelSize = sizes[0];
+      for (var i = 0; i < sizes.length; i++) {
+        if (sizes[i] > maxPanelSize) {
+          maxPanelSize = sizes[i];
+          maxIndex = i;
         }
+      }
+      sizes[maxIndex] -= adjustmentNeeded;
+      return sizes;
+    }
 
-        //////
-        // Component Lifecycle
-        //////
+    /**
+     * Return a new array of sizes with the adjustment made
+     * The adjustment is to add adjustmentNeeded to the smallest size in the array
+     *
+     * @param originalSizes
+     * @param adjustmentNeeded
+     */
 
-    }, {
-        key: "componentWillReceiveProps",
-        value: function componentWillReceiveProps(newProps) {
-            if (newProps.weights) {
-                var weights = this.props.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
-                // console.log("componentWillReceiveProps updating with weights: ", weights);
-                this.updateSizes(weights);
-            }
+  }, {
+    key: "adjustMinUp",
+    value: function adjustMinUp(originalSizes, adjustmentNeeded) {
+      var sizes = _lodash2.default.clone(originalSizes);
+      var minIndex = 0;
+      var minPanelSize = sizes[0];
+      for (var i = 0; i < sizes.length; i++) {
+        if (sizes[i] < minPanelSize) {
+          minPanelSize = sizes[i];
+          minIndex = i;
         }
-    }, {
-        key: "componentDidMount",
-        value: function componentDidMount() {
-            var _this3 = this;
+      }
+      sizes[minIndex] += adjustmentNeeded;
+      return sizes;
+    }
 
-            window.addEventListener("mouseup", this.onMouseUp);
-            window.addEventListener("mousemove", this.onMouseMove);
-            // We do this here because we can't guarantee that the event handler will be
-            // added before data is assigned if we do it in the JSX.
-            this.refs.resizeHackObject.addEventListener("load", function () {
-                return _this3.onResizeHackObjectLoad();
-            });
-            this.refs.resizeHackObject.data = "about:blank";
-            this.updateSizes();
+    /**
+     * Adjust the weights based on the expected sizes in pixels and the dom container size
+     * When the user moves the divider quickly, the weights get bigger/smaller than they should
+     * This is how we adjust to respect minPanelSize and the dom container size
+     *
+     * @param weights
+     * @returns {*}
+     */
+
+  }, {
+    key: "adjust",
+    value: function adjust(weights) {
+      var sizesAndOffsets = this.calcSizesAndOffsets(weights);
+      var sizes = sizesAndOffsets.sizes;
+      // const offsets = sizesAndOffsets.offsets;
+      var sumOfSizes = _lodash2.default.sum(sizes);
+      var domContainerSize = this.refs.self[this.domSizeProperty];
+      var expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
+      var diff = sumOfSizes - expectedSumOfSizes;
+
+      if (diff > 0) {
+        // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
+        var adjustedSizes = this.adjustMaxDown(sizes, diff);
+        return _lodash2.default.map(adjustedSizes, function (size) {
+          return size / expectedSumOfSizes * 100;
+        });
+      } else if (diff < 0) {
+        var absDiff = -diff;
+        // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
+        var _adjustedSizes = this.adjustMinUp(sizes, absDiff);
+        return _lodash2.default.map(_adjustedSizes, function (size) {
+          return size / expectedSumOfSizes * 100;
+        });
+      }
+
+      return weights;
+    }
+
+    /**
+     * Return the amount of pixels this panel should take up
+     * Take into account the number of weights, and the space that the dividers take up
+     *
+     * Example
+     *   There are 4 weights, and the current one is 27%
+     *   The container is 1000px, and the dividers are 5px
+     *   4 weights means 3 dividers. The total space they take up is then 15px
+     *   The total amount of pixels that the panels themselves can take up is 1000px - 15px = 985px
+     *   27% of 985px is 265.95px
+     *
+     * @param weights
+     * @param index
+     * @returns {number}
+     */
+
+  }, {
+    key: "weightToPx",
+    value: function weightToPx(weights, index) {
+      // Should always be 100, todo consider validating here
+      var totalWeight = _lodash2.default.sum(weights);
+
+      // The current weight's proportion of the entire container (so 27% becomes 0.27)
+      var proportion = weights[index] / totalWeight;
+
+      var totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+      var spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+      return proportion * spaceLeftForPanels;
+    }
+
+    /**
+     * Return the weight that this amount of pixels corresponds to
+     *
+     * @param weights
+     * @param pixels
+     * @returns {number}
+     */
+
+  }, {
+    key: "pxToWeight",
+    value: function pxToWeight(weights, pixels) {
+      var totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+      var spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+      return 100 * pixels / spaceLeftForPanels;
+    }
+
+    /**
+     * Calculate the precise sizes and offsets using the desired weights, the dom container size,
+     * and the size taken up by the dividers
+     *
+     * @param weights
+     * @returns {{sizes: Array, offsets: Array}}
+     */
+
+  }, {
+    key: "calcSizesAndOffsets",
+    value: function calcSizesAndOffsets(weights) {
+      weights = weights || this.weights;
+      var offsets = [];
+      var sizes = [];
+      for (var i = 0; i < weights.length; i++) {
+        var totalDividerSizeSoFar = i * this.dividerSize;
+        var sizeInPx = this.weightToPx(weights, i);
+        offsets.push(i === 0 ? 0 : _lodash2.default.sum(sizes) + totalDividerSizeSoFar);
+        sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
+      }
+      return { sizes: sizes, offsets: offsets };
+    }
+
+    /**
+     * Recalculates the size of each panel according to the weights, taking into
+     * account the space used by the dividers then updates this.state.sizes
+     * and this.state.offsets.
+     */
+
+  }, {
+    key: "updateSizes",
+    value: function updateSizes(weights) {
+      var sizesAndOffsets = this.calcSizesAndOffsets(weights);
+      this.setState(sizesAndOffsets);
+    }
+
+    /**
+     * Make up for too few or too many child elements by padding or truncating the weights
+     * Return a new array of weights
+     *
+     * @param originalWeights
+     * @returns {*}
+     */
+
+  }, {
+    key: "padOrTruncateWeights",
+    value: function padOrTruncateWeights(originalWeights) {
+      var children = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.children;
+
+      var weights = _lodash2.default.clone(originalWeights);
+      var numChildren = _react2.default.Children.count(children);
+      if (weights.length < numChildren) {
+        var minWeight = this.pxToWeight(weights, this.props.minPanelSize);
+        console.warn("SplitPanel: Only " + weights.length + " weights specified " + ("but there are " + numChildren + " subpanels; using " + minWeight + " for the ") + "remaining subpanels");
+        while (weights.length < numChildren) {
+          weights.push(minWeight);
         }
-    }, {
-        key: "componentWillUnmount",
-        value: function componentWillUnmount() {
-            window.removeEventListener("mouseup", this.onMouseUp);
-            window.removeEventListener("mousemove", this.onMouseMove);
-        }
+        return weights;
+      } else if (weights.length > numChildren) {
+        console.warn("SplitPanel: " + weights.length + " weights specified but " + ("there are only " + numChildren + " subpanels; ignoring additional weights"));
+        return weights.splice(0, numChildren);
+      }
+      return weights;
+    }
+  }, {
+    key: "weights",
+    get: function get() {
+      var weights = null;
+      if (this.props.weights && this.props.weights.length) {
+        weights = this.props.weights;
+      } else if (this.state.weights && this.state.weights.length) {
+        weights = this.state.weights;
+      } else if (this.props.defaultWeights && this.props.defaultWeights.length) {
+        weights = this.props.defaultWeights;
+      } else {
+        throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
+      }
+      return this.padOrTruncateWeights(weights);
+    }
+  }, {
+    key: "cursorPositionProperty",
+    get: function get() {
+      return this.props.direction == "horizontal" ? "clientX" : "clientY";
+    }
+  }, {
+    key: "cssSizeProperty",
+    get: function get() {
+      return this.props.direction == "horizontal" ? "width" : "height";
+    }
+  }, {
+    key: "cssOffsetProperty",
+    get: function get() {
+      return this.props.direction == "horizontal" ? "left" : "top";
+    }
+  }, {
+    key: "domSizeProperty",
+    get: function get() {
+      return this.props.direction == "horizontal" ? "clientWidth" : "clientHeight";
+    }
+  }, {
+    key: "dividerSize",
+    get: function get() {
+      // During the initial render we can't calculate this, so default to 5px.
+      // A fresh render is forced after the component is mounted to it doesn't
+      // matter.
+      if (this.refs["divider-0"]) {
+        return this.refs["divider-0"][this.domSizeProperty];
+      } else {
+        return 5;
+      }
+    }
+  }, {
+    key: "sizes",
+    get: function get() {
+      var numChildren = _react2.default.Children.count(this.props.children);
+      if (this.state.sizes.length == numChildren) {
+        return this.state.sizes;
+      } else {
+        // XXX: We can't calculate the sizes until the component has been rendered
+        // at least once (so we can't just call this.updateSizes() here) because
+        // we need to obtain the divider size from the DOM.
+        // Instead we say that all the panels are at the minimum size and hope
+        // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
+        // this is.
+        return _lodash2.default.fill(new Array(numChildren), this.props.minPanelSize);
+      }
+    }
+  }, {
+    key: "offsets",
+    get: function get() {
+      var numChildren = _react2.default.Children.count(this.props.children);
+      if (this.state.offsets.length == numChildren) {
+        return this.state.offsets;
+      } else {
+        // See the comment in `get sizes()`. The same applies here.
+        return _lodash2.default.fill(new Array(numChildren), 0);
+      }
+    }
+  }]);
 
-        //////
-        // Properties
-        //////
-        /**
-         * Gets the weights for each panel. This prefers this.props.weights, falling
-         * through to this.state.weights then this.props.defaultWeights.
-         *
-         * An Error is thrown if no weights are specified.
-         */
-
-    }, {
-        key: "onResizeHackObjectLoad",
-
-
-        //////
-        // Event Handlers
-        //////
-        value: function onResizeHackObjectLoad() {
-            var _this4 = this;
-
-            this.refs.resizeHackObject.contentDocument.defaultView.addEventListener("resize", function () {
-                return _this4.updateSizes();
-            });
-        }
-    }, {
-        key: "onDividerMouseDown",
-        value: function onDividerMouseDown(e, dividerIndex) {
-            var newState = {
-                activeDividerIndex: dividerIndex,
-                lastCursorPosition: e[this.cursorPositionProperty]
-            };
-            this.setState(newState);
-        }
-    }, {
-        key: "onMouseUp",
-        value: function onMouseUp() {
-            //Adjust any messed up state at this point
-            //So they can drag around as much as they want, and state will get out of whack
-            //But as soon as they let go it'll fix itself
-            var mouseIsDown = this.state.activeDividerIndex !== -1;
-            var weights = this.weights;
-            if (mouseIsDown && this.props.doAdjustmentOnMouseUp && weights) {
-                var adjustedWeights = this.adjust(weights);
-                this.emitWeightChange(adjustedWeights);
-            }
-
-            this.setState({ activeDividerIndex: -1 });
-        }
-    }, {
-        key: "onMouseMove",
-        value: function onMouseMove(e) {
-            if (this.state.activeDividerIndex == -1) return;
-            // If moving backwards (left or up) grow the next panel by taking space
-            // from the previous one. If moving forwards (right or down) grow the
-            // previous panel by taking space from the next.
-            //
-            // Horizontal: <previous>|<next>
-            // Vertical:
-            //  <previous>
-            //  ----------
-            //  <next>
-            var prevIndex = this.state.activeDividerIndex;
-            var nextIndex = prevIndex + 1;
-            // First obtain the size difference, rounding it down to a multiple of
-            // the step size...
-            var diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
-            var steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
-            if (steppedDiff == 0) {
-                // No change.
-                return;
-            }
-            // ...then make it proportional to the total weight rather than the
-            // container size.
-            var weights = this.weights;
-            var weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _lodash2.default.sum(weights);
-
-            // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
-            var weightPrev = weights[prevIndex];
-            var weightNext = weights[nextIndex];
-            var minWeight = this.pxToWeight(weights, this.props.minPanelSize);
-
-            function weightViolated(weight, minWeight, directionIsWrong) {
-                return weight <= minWeight && directionIsWrong;
-            }
-
-            //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
-            var prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
-
-            //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
-            var nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
-
-            // console.log("prevWeightViolated", prevWeightViolated);
-            // console.log("nextWeightViolated", nextWeightViolated);
-
-            if (this.props.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
-                return;
-            }
-
-            // If weightDiff is negative we're moving backwards, so this will shrink
-            // <previous> and grow <next>. Otherwise, we're moving forwards and
-            // <previous> will grow while <next> shrinks.
-            weights[prevIndex] += weightDiff;
-            weights[nextIndex] -= weightDiff;
-
-            if (this.props.doAdjustmentOnMouseMove) {
-                var adjustedWeights = this.adjust(weights);
-                this.emitWeightChange(adjustedWeights);
-            } else {
-                this.emitWeightChange(weights);
-            }
-            var newState = {
-                // We subtract the portion of the difference that we discarded to avoid
-                // accumulating rounding errors resulting in the cursor and divider
-                // positions drifting apart.
-                lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
-            };
-            this.setState(newState);
-        }
-
-        //////
-        // Event Emitters
-        //////
-
-    }, {
-        key: "emitWeightChange",
-        value: function emitWeightChange(newWeights) {
-            var _this5 = this;
-
-            // Only set weights on the state if we don't expect the parent to
-            // accept/reject the new weights by updating this.props.weights.
-            if (this.props.defaultWeights && this.props.defaultWeights.length) {
-                this.setState({ weights: newWeights }, function () {
-                    return _this5.updateSizes();
-                });
-            }
-            // Notify the parent that we'd like to change the weights.
-            if (this.props.onWeightChange) {
-                this.props.onWeightChange(newWeights);
-            }
-        }
-
-        //////
-        // Utilities
-        //////
-
-
-        /**
-         * Caution, mutating params
-         *
-         * @param sizes
-         * @param adjustmentNeeded
-         */
-
-    }, {
-        key: "adjustMaxDown",
-        value: function adjustMaxDown(sizes, adjustmentNeeded) {
-            var maxIndex = 0;
-            var maxPanelSize = sizes[0];
-            for (var i = 0; i < sizes.length; i++) {
-                if (sizes[i] > maxPanelSize) {
-                    maxPanelSize = sizes[i];
-                    maxIndex = i;
-                }
-            }
-            sizes[maxIndex] -= adjustmentNeeded;
-        }
-    }, {
-        key: "adjustMinUp",
-        value: function adjustMinUp(sizes, adjustmentNeeded) {
-            var minIndex = 0;
-            var minPanelSize = sizes[0];
-            for (var i = 0; i < sizes.length; i++) {
-                if (sizes[i] < minPanelSize) {
-                    minPanelSize = sizes[i];
-                    minIndex = i;
-                }
-            }
-            sizes[minIndex] += adjustmentNeeded;
-        }
-    }, {
-        key: "adjust",
-        value: function adjust(weights) {
-            //correct for sizes that got too big or too small
-            var sizesAndOffsets = this.calcSizesAndOffsets(weights);
-            var sizes = sizesAndOffsets.sizes;
-            // const offsets = sizesAndOffsets.offsets;
-            var sumOfSizes = _lodash2.default.sum(sizes);
-            var domContainerSize = this.refs.self[this.domSizeProperty];
-            var expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
-            var diff = sumOfSizes - expectedSumOfSizes;
-
-            if (diff > 0) {
-                // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
-                this.adjustMaxDown(sizes, diff);
-                return _lodash2.default.map(sizes, function (size) {
-                    return size / expectedSumOfSizes * 100;
-                });
-            } else if (diff < 0) {
-                var absDiff = -diff;
-                // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
-                this.adjustMinUp(sizes, absDiff);
-                return _lodash2.default.map(sizes, function (size) {
-                    return size / expectedSumOfSizes * 100;
-                });
-            }
-
-            return weights;
-        }
-
-        /**
-         * Return the amount of pixels this panel should take up
-         * Take into account the number of weights, and the space that the dividers take up
-         *
-         * Example
-         *   There are 4 weights, and the current one is 27%
-         *   The container is 1000px, and the dividers are 5px
-         *   4 weights means 3 dividers. The total space they take up is then 15px
-         *   The total amount of pixels that the panels themselves can take up is 1000px - 15px = 985px
-         *   27% of 985px is 265.95px
-         *
-         * @param weights
-         * @param index
-         * @returns {number}
-         */
-
-    }, {
-        key: "weightToPx",
-        value: function weightToPx(weights, index) {
-            // Should always be 100, todo consider validating here
-            var totalWeight = _lodash2.default.sum(weights);
-
-            // The current weight's proportion of the entire container (so 27% becomes 0.27)
-            var proportion = weights[index] / totalWeight;
-
-            var totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
-
-            var spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
-
-            return proportion * spaceLeftForPanels;
-        }
-
-        /**
-         * Return the weight that this amount of pixels corresponds to
-         *
-         * @param weights
-         * @param pixels
-         * @returns {number}
-         */
-
-    }, {
-        key: "pxToWeight",
-        value: function pxToWeight(weights, pixels) {
-            var totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
-
-            var spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
-
-            return 100 * pixels / spaceLeftForPanels;
-        }
-    }, {
-        key: "calcSizesAndOffsets",
-        value: function calcSizesAndOffsets(weights, children) {
-            weights = weights || this.weights;
-            weights = this.padOrTruncateWeights(weights, children);
-            var offsets = [];
-            var sizes = [];
-            for (var i = 0; i < weights.length; i++) {
-                var totalDividerSizeSoFar = i * this.dividerSize;
-                var sizeInPx = this.weightToPx(weights, i);
-                offsets.push(i === 0 ? 0 : _lodash2.default.sum(sizes) + totalDividerSizeSoFar);
-                sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
-            }
-            return { sizes: sizes, offsets: offsets };
-        }
-
-        /**
-         * Recalculates the size of each panel according to the weights, taking into
-         * account the space used by the dividers then updates this.state.sizes
-         * and this.state.offsets.
-         */
-
-    }, {
-        key: "updateSizes",
-        value: function updateSizes(weights, children) {
-            var sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
-            // console.log("sizesAndOffsets", sizesAndOffsets);
-            this.setState(sizesAndOffsets);
-        }
-
-        /**
-         * Caution, mutating params
-         *
-         * @param weights
-         * @returns {*}
-         */
-
-    }, {
-        key: "padOrTruncateWeights",
-        value: function padOrTruncateWeights(weights) {
-            var children = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : this.props.children;
-
-            return weights;
-            // console.log("padOrTruncateWeights");
-            // console.log("weights", weights);
-            // console.log("children", children);
-            // const numChildren = React.Children.count(children);
-            // if (weights.length < numChildren) {
-            //   const min = Math.max(_.min(weights), this.props.minPanelSize);
-            //   console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
-            //     `but there are ${numChildren} subpanels; using ${min} for the ` +
-            //     `remaining subpanels`);
-            //   while (weights.length < numChildren) {
-            //     weights.push(min);
-            //   }
-            // }
-            // else if (weights.length > numChildren) {
-            //   console.warn(`SplitPanel: ${weights.length} weights specified but ` +
-            //     `there are only ${numChildren} subpanels; ignoring additional weights`);
-            //   weights = weights.splice(0, numChildren);
-            // }
-            // return weights;
-        }
-    }, {
-        key: "weights",
-        get: function get() {
-            var weights = null;
-            if (this.props.weights && this.props.weights.length) {
-                weights = this.props.weights;
-            } else if (this.state.weights && this.state.weights.length) {
-                weights = this.state.weights;
-            } else if (this.props.defaultWeights && this.props.defaultWeights.length) {
-                weights = this.props.defaultWeights;
-            } else {
-                throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
-            }
-            return this.padOrTruncateWeights(weights);
-        }
-    }, {
-        key: "cursorPositionProperty",
-        get: function get() {
-            return this.props.direction == "horizontal" ? "clientX" : "clientY";
-        }
-    }, {
-        key: "cssSizeProperty",
-        get: function get() {
-            return this.props.direction == "horizontal" ? "width" : "height";
-        }
-    }, {
-        key: "cssOffsetProperty",
-        get: function get() {
-            return this.props.direction == "horizontal" ? "left" : "top";
-        }
-    }, {
-        key: "domSizeProperty",
-        get: function get() {
-            return this.props.direction == "horizontal" ? "clientWidth" : "clientHeight";
-        }
-    }, {
-        key: "dividerSize",
-        get: function get() {
-            // During the initial render we can't calculate this, so default to 5px.
-            // A fresh render is forced after the component is mounted to it doesn't
-            // matter.
-            if (this.refs["divider-0"]) {
-                return this.refs["divider-0"][this.domSizeProperty];
-            } else {
-                return 5;
-            }
-        }
-    }, {
-        key: "sizes",
-        get: function get() {
-            var numChildren = _react2.default.Children.count(this.props.children);
-            if (this.state.sizes.length == numChildren) {
-                return this.state.sizes;
-            } else {
-                // XXX: We can't calculate the sizes until the component has been rendered
-                // at least once (so we can't just call this.updateSizes() here) because
-                // we need to obtain the divider size from the DOM.
-                // Instead we say that all the panels are at the minimum size and hope
-                // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
-                // this is.
-                return _lodash2.default.fill(new Array(numChildren), this.props.minPanelSize);
-            }
-        }
-    }, {
-        key: "offsets",
-        get: function get() {
-            var numChildren = _react2.default.Children.count(this.props.children);
-            if (this.state.offsets.length == numChildren) {
-                return this.state.offsets;
-            } else {
-                // See the comment in `get sizes()`. The same applies here.
-                return _lodash2.default.fill(new Array(numChildren), 0);
-            }
-        }
-    }]);
-
-    return SplitPanel;
+  return SplitPanel;
 }(_react2.default.Component);
 
 SplitPanel.propTypes = {
-    /**
-     * The direction to layout subpanels. One of "horizontal" or "vertical".
-     *
-     * Default: horizontal
-     */
-    direction: _react2.default.PropTypes.oneOf(["horizontal", "vertical"]),
+  /**
+   * The direction to layout subpanels. One of "horizontal" or "vertical".
+   *
+   * Default: horizontal
+   */
+  direction: _react2.default.PropTypes.oneOf(["horizontal", "vertical"]),
 
-    /**
-     * The minimum size (in pixels) of a subpanel. The divider will stop
-     * abruptly if the user attempts to shrink a subpanel below this size.
-     *
-     * Default: 25
-     */
-    minPanelSize: _react2.default.PropTypes.number,
+  /**
+   * The minimum size (in pixels) of a subpanel. The divider will stop
+   * abruptly if the user attempts to shrink a subpanel below this size.
+   *
+   * Default: 25
+   */
+  minPanelSize: _react2.default.PropTypes.number,
 
-    /**
-     * Called whenever a subpanel is resized.
-     *
-     * You should update `weights` in response to this event unless you're
-     * using `defaultWeights`.
-     */
-    onWeightChange: _react2.default.PropTypes.func,
+  /**
+   * Called whenever a subpanel is resized.
+   *
+   * You should update `weights` in response to this event unless you're
+   * using `defaultWeights`.
+   */
+  onWeightChange: _react2.default.PropTypes.func,
 
-    /**
-     * The weights of each subpanel. If you're using this property you must
-     * manually update this prop in response to `onWeightChange` otherwise
-     * the subpanels will not resize.
-     */
-    weights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
+  /**
+   * The weights of each subpanel. If you're using this property you must
+   * manually update this prop in response to `onWeightChange` otherwise
+   * the subpanels will not resize.
+   */
+  weights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
 
-    /**
-     * The default weights to use when you are not managing the weights
-     * manually via the `weights` and `onWeightChange` props.
-     */
-    defaultWeights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
+  /**
+   * The default weights to use when you are not managing the weights
+   * manually via the `weights` and `onWeightChange` props.
+   */
+  defaultWeights: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
 
-    /**
-     * The resize step size in pixels.
-     *
-     * Useful if you have monospaced text and you want to ensure the panel
-     * is resized in increments of one character width.
-     *
-     * Default: 1
-     */
-    stepSize: _react2.default.PropTypes.number,
+  /**
+   * The resize step size in pixels.
+   *
+   * Useful if you have monospaced text and you want to ensure the panel
+   * is resized in increments of one character width.
+   *
+   * Default: 1
+   */
+  stepSize: _react2.default.PropTypes.number,
 
-    /**
-     * Bool that controls adjustment on mouse up functionality
-     *
-     * Used to adjust the weights after a fast mousemove by the user
-     * Without it they may start to exceed the dimensions of the container
-     *
-     * Default: true
-     */
-    doAdjustmentOnMouseUp: _react2.default.PropTypes.bool,
+  /**
+   * Bool that controls adjustment on mouse up functionality
+   *
+   * Used to adjust the weights after a fast mousemove by the user
+   * Without it they may start to exceed the dimensions of the container
+   *
+   * Default: true
+   */
+  doAdjustmentOnMouseUp: _react2.default.PropTypes.bool,
 
-    /**
-     * Bool that controls exit on violation during mouse move functionality
-     *
-     * During the mouse move, if the minPanelSize is violated,
-     * Don't go through with the state change
-     *
-     * Default: true
-     */
-    exitMouseMoveOnViolation: _react2.default.PropTypes.bool,
+  /**
+   * Bool that controls exit on violation during mouse move functionality
+   *
+   * During the mouse move, if the minPanelSize is violated,
+   * Don't go through with the state change
+   *
+   * Default: true
+   */
+  exitMouseMoveOnViolation: _react2.default.PropTypes.bool,
 
-    /**
-     * Bool that controls adjustment on componentWillReceiveProps
-     *
-     * Used to adjust the weights when getting new props
-     *
-     * Default: true
-     */
-    adjustOnReceiveProps: _react2.default.PropTypes.bool,
+  /**
+   * Bool that controls adjustment on componentWillReceiveProps
+   *
+   * Used to adjust the weights when getting new props
+   *
+   * Default: true
+   */
+  adjustOnReceiveProps: _react2.default.PropTypes.bool,
 
-    /**
-     * Bool that controls adjustment on mouse move functionality
-     *
-     * Used to adjust the weights during a fast mousemove by the user
-     * Without it they may start to exceed the dimensions of the container
-     * This one is a bit risky since the action is in the middle of happening
-     * Optional and not recommended unless you're getting better results with it
-     *
-     * Default: false
-     */
-    doAdjustmentOnMouseMove: _react2.default.PropTypes.bool
+  /**
+   * Bool that controls adjustment on mouse move functionality
+   *
+   * Used to adjust the weights during a fast mousemove by the user
+   * Without it they may start to exceed the dimensions of the container
+   * This one is a bit risky since the action is in the middle of happening
+   * Optional and not recommended unless you're getting better results with it
+   *
+   * Default: false
+   */
+  doAdjustmentOnMouseMove: _react2.default.PropTypes.bool
 };
 SplitPanel.defaultProps = {
-    direction: "horizontal",
-    minPanelSize: 25,
-    stepSize: 1,
-    doAdjustmentOnMouseUp: true,
-    exitMouseMoveOnViolation: true,
-    adjustOnReceiveProps: true,
-    doAdjustmentOnMouseMove: false
+  direction: "horizontal",
+  minPanelSize: 25,
+  stepSize: 1,
+  doAdjustmentOnMouseUp: true,
+  exitMouseMoveOnViolation: true,
+  adjustOnReceiveProps: true,
+  doAdjustmentOnMouseMove: false
 };
 exports.default = SplitPanel;

--- a/dist/SplitPanel.js
+++ b/dist/SplitPanel.js
@@ -360,22 +360,22 @@ var SplitPanel = function (_React$Component) {
       var offsets = sizesAndOffsets.offsets;
       var sumOfSizes = _lodash2.default.sum(sizes);
       var domContainerSize = this.refs.self[this.domSizeProperty];
-      var expectedSumOfSizes = domContainerSize - weights.length - 1 * this.dividerSize;
+      var expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
       var diff = sumOfSizes - expectedSumOfSizes;
-      // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
 
       if (diff > 0) {
+        // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
         this.adjustMaxDown(sizes, diff);
-        var adjustedWeights = _lodash2.default.map(sizes, function (size) {
+        return _lodash2.default.map(sizes, function (size) {
           return size / expectedSumOfSizes * 100;
         });
-        return adjustedWeights;
       } else if (diff < 0) {
-        this.adjustMinUp(sizes, diff);
-        var _adjustedWeights = _lodash2.default.map(sizes, function (size) {
+        var absDiff = -diff;
+        // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
+        this.adjustMinUp(sizes, absDiff);
+        return _lodash2.default.map(sizes, function (size) {
           return size / expectedSumOfSizes * 100;
         });
-        return _adjustedWeights;
       }
 
       return weights;

--- a/src/SplitPanel.jsx
+++ b/src/SplitPanel.jsx
@@ -17,558 +17,583 @@ import _ from "lodash";
  * used for all remaining elements. Any additional weights will be ignored.
  */
 export default class SplitPanel extends React.Component {
-    static propTypes = {
-        /**
-         * The direction to layout subpanels. One of "horizontal" or "vertical".
-         *
-         * Default: horizontal
-         */
-        direction: React.PropTypes.oneOf(["horizontal", "vertical"]),
+  static propTypes = {
+    /**
+     * The direction to layout subpanels. One of "horizontal" or "vertical".
+     *
+     * Default: horizontal
+     */
+    direction: React.PropTypes.oneOf(["horizontal", "vertical"]),
 
-        /**
-         * The minimum size (in pixels) of a subpanel. The divider will stop
-         * abruptly if the user attempts to shrink a subpanel below this size.
-         *
-         * Default: 25
-         */
-        minPanelSize: React.PropTypes.number,
+    /**
+     * The minimum size (in pixels) of a subpanel. The divider will stop
+     * abruptly if the user attempts to shrink a subpanel below this size.
+     *
+     * Default: 25
+     */
+    minPanelSize: React.PropTypes.number,
 
-        /**
-         * Called whenever a subpanel is resized.
-         *
-         * You should update `weights` in response to this event unless you're
-         * using `defaultWeights`.
-         */
-        onWeightChange: React.PropTypes.func,
+    /**
+     * Called whenever a subpanel is resized.
+     *
+     * You should update `weights` in response to this event unless you're
+     * using `defaultWeights`.
+     */
+    onWeightChange: React.PropTypes.func,
 
-        /**
-         * The weights of each subpanel. If you're using this property you must
-         * manually update this prop in response to `onWeightChange` otherwise
-         * the subpanels will not resize.
-         */
-        weights: React.PropTypes.arrayOf(React.PropTypes.number),
+    /**
+     * The weights of each subpanel. If you're using this property you must
+     * manually update this prop in response to `onWeightChange` otherwise
+     * the subpanels will not resize.
+     */
+    weights: React.PropTypes.arrayOf(React.PropTypes.number),
 
-        /**
-         * The default weights to use when you are not managing the weights
-         * manually via the `weights` and `onWeightChange` props.
-         */
-        defaultWeights: React.PropTypes.arrayOf(React.PropTypes.number),
+    /**
+     * The default weights to use when you are not managing the weights
+     * manually via the `weights` and `onWeightChange` props.
+     */
+    defaultWeights: React.PropTypes.arrayOf(React.PropTypes.number),
 
-        /**
-         * The resize step size in pixels.
-         *
-         * Useful if you have monospaced text and you want to ensure the panel
-         * is resized in increments of one character width.
-         *
-         * Default: 1
-         */
-        stepSize: React.PropTypes.number,
+    /**
+     * The resize step size in pixels.
+     *
+     * Useful if you have monospaced text and you want to ensure the panel
+     * is resized in increments of one character width.
+     *
+     * Default: 1
+     */
+    stepSize: React.PropTypes.number,
 
-        /**
-         * Bool that controls adjustment on mouse up functionality
-         *
-         * Used to adjust the weights after a fast mousemove by the user
-         * Without it they may start to exceed the dimensions of the container
-         *
-         * Default: true
-         */
-        doAdjustmentOnMouseUp: React.PropTypes.bool,
+    /**
+     * Bool that controls adjustment on mouse up functionality
+     *
+     * Used to adjust the weights after a fast mousemove by the user
+     * Without it they may start to exceed the dimensions of the container
+     *
+     * Default: true
+     */
+    doAdjustmentOnMouseUp: React.PropTypes.bool,
 
-        /**
-         * Bool that controls exit on violation during mouse move functionality
-         *
-         * During the mouse move, if the minPanelSize is violated,
-         * Don't go through with the state change
-         *
-         * Default: true
-         */
-        exitMouseMoveOnViolation: React.PropTypes.bool,
+    /**
+     * Bool that controls exit on violation during mouse move functionality
+     *
+     * During the mouse move, if the minPanelSize is violated,
+     * Don't go through with the state change
+     *
+     * Default: true
+     */
+    exitMouseMoveOnViolation: React.PropTypes.bool,
 
-        /**
-         * Bool that controls adjustment on componentWillReceiveProps
-         *
-         * Used to adjust the weights when getting new props
-         *
-         * Default: true
-         */
-        adjustOnReceiveProps: React.PropTypes.bool,
+    /**
+     * Bool that controls adjustment on componentWillReceiveProps
+     *
+     * Used to adjust the weights when getting new props
+     *
+     * Default: true
+     */
+    adjustOnReceiveProps: React.PropTypes.bool,
 
-        /**
-         * Bool that controls adjustment on mouse move functionality
-         *
-         * Used to adjust the weights during a fast mousemove by the user
-         * Without it they may start to exceed the dimensions of the container
-         * This one is a bit risky since the action is in the middle of happening
-         * Optional and not recommended unless you're getting better results with it
-         *
-         * Default: false
-         */
-        doAdjustmentOnMouseMove: React.PropTypes.bool
+    /**
+     * Bool that controls adjustment on mouse move functionality
+     *
+     * Used to adjust the weights during a fast mousemove by the user
+     * Without it they may start to exceed the dimensions of the container
+     * This one is a bit risky since the action is in the middle of happening
+     * Optional and not recommended unless you're getting better results with it
+     *
+     * Default: false
+     */
+    doAdjustmentOnMouseMove: React.PropTypes.bool
+  };
+
+  static defaultProps = {
+    direction: "horizontal",
+    minPanelSize: 25,
+    stepSize: 1,
+    doAdjustmentOnMouseUp: true,
+    exitMouseMoveOnViolation: true,
+    adjustOnReceiveProps: true,
+    doAdjustmentOnMouseMove: false
+  };
+
+  constructor() {
+    super();
+
+    this.state = {
+      // The last position of the cursor. Used by onMouseMove to calculate
+      // relative changes in divider position.
+      lastCursorPosition: 0,
+      // Sizes of the subpanels taking into account the weights and divider
+      // size.
+      sizes: [],
+      // Offsets of each subpanel.
+      offsets: [],
+      // The index of the divider currently being dragged by the user.
+      activeDividerIndex: -1,
     };
 
-    static defaultProps = {
-        direction: "horizontal",
-        minPanelSize: 25,
-        stepSize: 1,
-        doAdjustmentOnMouseUp: true,
-        exitMouseMoveOnViolation: true,
-        adjustOnReceiveProps: true,
-        doAdjustmentOnMouseMove: false
+    // Bind event listeners in advance.
+    this.onDividerMouseDown = this.onDividerMouseDown.bind(this);
+    // These two are attached to `window` because sometimes due to glitches we
+    // can't do very much about we'll be unable to move the divider in time to
+    // keep up with the mouse cursor, but we still need to move the divider to
+    // catch up and to release it when the user releases the divider.
+    // N.B. These are attached in componentDidMount and detached in
+    // componentWillUnmount.
+    this.onMouseMove = this.onMouseMove.bind(this);
+    this.onMouseUp = this.onMouseUp.bind(this);
+  }
+
+  render() {
+
+    // Create a sized splitPanelItem with a divider for each child, except...
+    const childrenWithDividers = [];
+    const children = React.Children.toArray(this.props.children);
+    for (let i = 0; i < children.length; i++) {
+      const style = {
+        [this.cssSizeProperty]: this.sizes[i],
+        [this.cssOffsetProperty]: this.offsets[i],
+      };
+
+      childrenWithDividers.push(<div key={`panel-${i}`}
+                                     className="split-panel-item"
+                                     style={style}>{children[i]}</div>);
+
+      // ...don't add a divider if it's the last panel.
+      if (i < children.length - 1) {
+        const dividerStyle = {
+          [this.cssOffsetProperty]: this.offsets[i + 1] - this.dividerSize,
+        };
+        childrenWithDividers.push(<div
+          key={`divider-${i}`} ref={`divider-${i}`}
+          className="split-panel-divider"
+          style={dividerStyle}
+          onMouseDown={e => this.onDividerMouseDown(e, i)}>
+        </div>);
+      }
+    }
+
+    // Because elements don't have a resize event we create an <object> with
+    // no content and filling the entire panel. When this object's
+    // contentDocument.resize event fires we know to update the sizes of all
+    // the subpanels. :-)
+    const resizeHackObject = <object className="split-panel-resize-hack-object"
+                                     ref="resizeHackObject"
+                                     type="text/html">
+    </object>;
+    const klass = classNames("split-panel", this.props.direction, {
+      "split-panel-resizing": this.state.activeDividerIndex != -1,
+    });
+    return <div ref="self" className={klass}>
+      {resizeHackObject}
+      {childrenWithDividers}
+    </div>;
+  }
+
+  //////
+  // Component Lifecycle
+  //////
+  componentWillReceiveProps(newProps) {
+    //Make sure to call padOrTruncateWeights with the children from newProps,
+    //Otherwise it'll check the old children and won't render properly until re-sized
+    if (newProps.weights) {
+      const weights = this.padOrTruncateWeights(newProps.weights, newProps.children);
+      const adjustedWeights = this.props.adjustOnReceiveProps ? this.adjust(weights) : weights;
+      this.updateSizes(adjustedWeights);
+    }
+  }
+
+  componentDidMount() {
+    window.addEventListener("mouseup", this.onMouseUp);
+    window.addEventListener("mousemove", this.onMouseMove);
+    // We do this here because we can't guarantee that the event handler will be
+    // added before data is assigned if we do it in the JSX.
+    this.refs.resizeHackObject.addEventListener("load", () => this.onResizeHackObjectLoad());
+    this.refs.resizeHackObject.data = "about:blank";
+    this.updateSizes();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("mouseup", this.onMouseUp);
+    window.removeEventListener("mousemove", this.onMouseMove);
+  }
+
+  //////
+  // Properties
+  //////
+  /**
+   * Gets the weights for each panel. This prefers this.props.weights, falling
+   * through to this.state.weights then this.props.defaultWeights.
+   *
+   * An Error is thrown if no weights are specified.
+   */
+  get weights() {
+    let weights = null;
+    if (this.props.weights && this.props.weights.length) {
+      weights = this.props.weights;
+    }
+    else if (this.state.weights && this.state.weights.length) {
+      weights = this.state.weights;
+    }
+    else if (this.props.defaultWeights && this.props.defaultWeights.length) {
+      weights = this.props.defaultWeights;
+    }
+    else {
+      throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
+    }
+    return this.padOrTruncateWeights(weights);
+  }
+
+  get cursorPositionProperty() {
+    return this.props.direction == "horizontal" ? "clientX" : "clientY";
+  }
+
+  get cssSizeProperty() {
+    return this.props.direction == "horizontal" ? "width" : "height";
+  }
+
+  get cssOffsetProperty() {
+    return this.props.direction == "horizontal" ? "left" : "top";
+  }
+
+  get domSizeProperty() {
+    return this.props.direction == "horizontal" ?
+      "clientWidth" : "clientHeight";
+  }
+
+  get dividerSize() {
+    // During the initial render we can't calculate this, so default to 5px.
+    // A fresh render is forced after the component is mounted to it doesn't
+    // matter.
+    if (this.refs["divider-0"]) {
+      return this.refs["divider-0"][this.domSizeProperty];
+    }
+    else {
+      return 5;
+    }
+  }
+
+  get sizes() {
+    const numChildren = React.Children.count(this.props.children);
+    if (this.state.sizes.length == numChildren) {
+      return this.state.sizes;
+    }
+    else {
+      // XXX: We can't calculate the sizes until the component has been rendered
+      // at least once (so we can't just call this.updateSizes() here) because
+      // we need to obtain the divider size from the DOM.
+      // Instead we say that all the panels are at the minimum size and hope
+      // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
+      // this is.
+      return _.fill(new Array(numChildren), this.props.minPanelSize);
+    }
+  }
+
+  get offsets() {
+    const numChildren = React.Children.count(this.props.children);
+    if (this.state.offsets.length == numChildren) {
+      return this.state.offsets;
+    }
+    else {
+      // See the comment in `get sizes()`. The same applies here.
+      return _.fill(new Array(numChildren), 0);
+    }
+  }
+
+  //////
+  // Event Handlers
+  //////
+  onResizeHackObjectLoad() {
+    this.refs.resizeHackObject.contentDocument.defaultView.addEventListener(
+      "resize", () => this.updateSizes());
+  }
+
+  onDividerMouseDown(e, dividerIndex) {
+    const newState = {
+      activeDividerIndex: dividerIndex,
+      lastCursorPosition: e[this.cursorPositionProperty],
     };
+    this.setState(newState);
+  }
 
-    constructor() {
-        super();
-
-        this.state = {
-            // The last position of the cursor. Used by onMouseMove to calculate
-            // relative changes in divider position.
-            lastCursorPosition: 0,
-            // Sizes of the subpanels taking into account the weights and divider
-            // size.
-            sizes: [],
-            // Offsets of each subpanel.
-            offsets: [],
-            // The index of the divider currently being dragged by the user.
-            activeDividerIndex: -1,
-        };
-
-        // Bind event listeners in advance.
-        this.onDividerMouseDown = this.onDividerMouseDown.bind(this);
-        // These two are attached to `window` because sometimes due to glitches we
-        // can't do very much about we'll be unable to move the divider in time to
-        // keep up with the mouse cursor, but we still need to move the divider to
-        // catch up and to release it when the user releases the divider.
-        // N.B. These are attached in componentDidMount and detached in
-        // componentWillUnmount.
-        this.onMouseMove = this.onMouseMove.bind(this);
-        this.onMouseUp = this.onMouseUp.bind(this);
+  onMouseUp() {
+    //Adjust any messed up state at this point
+    //So they can drag around as much as they want, and state will get out of whack
+    //But as soon as they let go it'll fix itself
+    const mouseIsDown = this.state.activeDividerIndex !== -1;
+    const weights = this.weights;
+    if (mouseIsDown && this.props.doAdjustmentOnMouseUp && weights) {
+      const adjustedWeights = this.adjust(weights);
+      this.emitWeightChange(adjustedWeights);
     }
 
-    render() {
+    this.setState({ activeDividerIndex: -1 });
+  }
 
-        // Create a sized splitPanelItem with a divider for each child, except...
-        const childrenWithDividers = [];
-        const children = React.Children.toArray(this.props.children);
-        for (let i = 0; i < children.length; i++) {
-            const style = {
-                [this.cssSizeProperty]: this.sizes[i],
-                [this.cssOffsetProperty]: this.offsets[i],
-            };
+  onMouseMove(e) {
+    if (this.state.activeDividerIndex == -1) return;
+    // If moving backwards (left or up) grow the next panel by taking space
+    // from the previous one. If moving forwards (right or down) grow the
+    // previous panel by taking space from the next.
+    //
+    // Horizontal: <previous>|<next>
+    // Vertical:
+    //  <previous>
+    //  ----------
+    //  <next>
+    const prevIndex = this.state.activeDividerIndex;
+    const nextIndex = prevIndex + 1;
+    // First obtain the size difference, rounding it down to a multiple of
+    // the step size...
+    const diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
+    const steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
+    if (steppedDiff == 0) {
+      // No change.
+      return;
+    }
+    // ...then make it proportional to the total weight rather than the
+    // container size.
+    const weights = this.weights;
+    const weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _.sum(weights);
 
-            childrenWithDividers.push(<div key={`panel-${i}`}
-                                           className="split-panel-item"
-                                           style={style}>{children[i]}</div>);
+    // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
+    const weightPrev = weights[prevIndex];
+    const weightNext = weights[nextIndex];
+    const minWeight = this.pxToWeight(weights, this.props.minPanelSize);
 
-            // ...don't add a divider if it's the last panel.
-            if (i < children.length - 1) {
-                const dividerStyle = {
-                    [this.cssOffsetProperty]: this.offsets[i + 1] - this.dividerSize,
-                };
-                childrenWithDividers.push(<div
-                    key={`divider-${i}`} ref={`divider-${i}`}
-                    className="split-panel-divider"
-                    style={dividerStyle}
-                    onMouseDown={e => this.onDividerMouseDown(e, i)}>
-                </div>);
-            }
-        }
-
-        // Because elements don't have a resize event we create an <object> with
-        // no content and filling the entire panel. When this object's
-        // contentDocument.resize event fires we know to update the sizes of all
-        // the subpanels. :-)
-        const resizeHackObject = <object className="split-panel-resize-hack-object"
-                                         ref="resizeHackObject"
-                                         type="text/html">
-        </object>;
-        const klass = classNames("split-panel", this.props.direction, {
-            "split-panel-resizing": this.state.activeDividerIndex != -1,
-        });
-        return <div ref="self" className={klass}>
-            {resizeHackObject}
-            {childrenWithDividers}
-        </div>;
+    function weightViolated(weight, minWeight, directionIsWrong) {
+      return (weight <= minWeight) && directionIsWrong;
     }
 
-    //////
-    // Component Lifecycle
-    //////
-    componentWillReceiveProps(newProps) {
-        if (newProps.weights) {
-            const weights = this.props.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
-            // console.log("componentWillReceiveProps updating with weights: ", weights);
-            this.updateSizes(weights);
-        }
+    //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
+    const prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
+
+    //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
+    const nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
+
+    // console.log("prevWeightViolated", prevWeightViolated);
+    // console.log("nextWeightViolated", nextWeightViolated);
+
+    if (this.props.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
+      return;
     }
 
-    componentDidMount() {
-        window.addEventListener("mouseup", this.onMouseUp);
-        window.addEventListener("mousemove", this.onMouseMove);
-        // We do this here because we can't guarantee that the event handler will be
-        // added before data is assigned if we do it in the JSX.
-        this.refs.resizeHackObject.addEventListener("load", () => this.onResizeHackObjectLoad());
-        this.refs.resizeHackObject.data = "about:blank";
-        this.updateSizes();
+    // If weightDiff is negative we're moving backwards, so this will shrink
+    // <previous> and grow <next>. Otherwise, we're moving forwards and
+    // <previous> will grow while <next> shrinks.
+    weights[prevIndex] += weightDiff;
+    weights[nextIndex] -= weightDiff;
+
+    if (this.props.doAdjustmentOnMouseMove) {
+      const adjustedWeights = this.adjust(weights);
+      this.emitWeightChange(adjustedWeights);
+    } else {
+      this.emitWeightChange(weights);
+    }
+    const newState = {
+      // We subtract the portion of the difference that we discarded to avoid
+      // accumulating rounding errors resulting in the cursor and divider
+      // positions drifting apart.
+      lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
+    };
+    this.setState(newState);
+  }
+
+  //////
+  // Event Emitters
+  //////
+  emitWeightChange(newWeights) {
+    // Only set weights on the state if we don't expect the parent to
+    // accept/reject the new weights by updating this.props.weights.
+    if (this.props.defaultWeights && this.props.defaultWeights.length) {
+      this.setState({ weights: newWeights }, () => this.updateSizes());
+    }
+    // Notify the parent that we'd like to change the weights.
+    if (this.props.onWeightChange) {
+      this.props.onWeightChange(newWeights);
+    }
+  }
+
+  //////
+  // Utilities
+  //////
+
+
+  /**
+   * Return a new array of sizes with the adjustment made
+   * The adjustment is to subtract adjustmentNeeded from the largest size in the array
+   *
+   * @param originalSizes
+   * @param adjustmentNeeded
+   */
+  adjustMaxDown(originalSizes, adjustmentNeeded) {
+    const sizes = _.clone(originalSizes);
+    let maxIndex = 0;
+    let maxPanelSize = sizes[0];
+    for (let i = 0; i < sizes.length; i++) {
+      if (sizes[i] > maxPanelSize) {
+        maxPanelSize = sizes[i];
+        maxIndex = i;
+      }
+    }
+    sizes[maxIndex] -= adjustmentNeeded;
+    return sizes;
+  }
+
+  /**
+   * Return a new array of sizes with the adjustment made
+   * The adjustment is to add adjustmentNeeded to the smallest size in the array
+   *
+   * @param originalSizes
+   * @param adjustmentNeeded
+   */
+  adjustMinUp(originalSizes, adjustmentNeeded) {
+    const sizes = _.clone(originalSizes);
+    let minIndex = 0;
+    let minPanelSize = sizes[0];
+    for (let i = 0; i < sizes.length; i++) {
+      if (sizes[i] < minPanelSize) {
+        minPanelSize = sizes[i];
+        minIndex = i;
+      }
+    }
+    sizes[minIndex] += adjustmentNeeded;
+    return sizes;
+  }
+
+  /**
+   * Adjust the weights based on the expected sizes in pixels and the dom container size
+   * When the user moves the divider quickly, the weights get bigger/smaller than they should
+   * This is how we adjust to respect minPanelSize and the dom container size
+   *
+   * @param weights
+   * @returns {*}
+   */
+  adjust(weights) {
+    const sizesAndOffsets = this.calcSizesAndOffsets(weights);
+    const sizes = sizesAndOffsets.sizes;
+    // const offsets = sizesAndOffsets.offsets;
+    const sumOfSizes = _.sum(sizes);
+    const domContainerSize = this.refs.self[this.domSizeProperty];
+    const expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
+    const diff = sumOfSizes - expectedSumOfSizes;
+
+    if (diff > 0) {
+      // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
+      const adjustedSizes = this.adjustMaxDown(sizes, diff);
+      return _.map(adjustedSizes, (size) => {
+        return size / expectedSumOfSizes * 100;
+      });
+    } else if (diff < 0) {
+      const absDiff = -diff;
+      // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
+      const adjustedSizes = this.adjustMinUp(sizes, absDiff);
+      return _.map(adjustedSizes, (size) => {
+        return size / expectedSumOfSizes * 100;
+      });
     }
 
-    componentWillUnmount() {
-        window.removeEventListener("mouseup", this.onMouseUp);
-        window.removeEventListener("mousemove", this.onMouseMove);
+    return weights;
+  }
+
+  /**
+   * Return the amount of pixels this panel should take up
+   * Take into account the number of weights, and the space that the dividers take up
+   *
+   * Example
+   *   There are 4 weights, and the current one is 27%
+   *   The container is 1000px, and the dividers are 5px
+   *   4 weights means 3 dividers. The total space they take up is then 15px
+   *   The total amount of pixels that the panels themselves can take up is 1000px - 15px = 985px
+   *   27% of 985px is 265.95px
+   *
+   * @param weights
+   * @param index
+   * @returns {number}
+   */
+  weightToPx(weights, index) {
+    // Should always be 100, todo consider validating here
+    const totalWeight = _.sum(weights);
+
+    // The current weight's proportion of the entire container (so 27% becomes 0.27)
+    const proportion = weights[index] / totalWeight;
+
+    const totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+    const spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+    return proportion * spaceLeftForPanels;
+  }
+
+  /**
+   * Return the weight that this amount of pixels corresponds to
+   *
+   * @param weights
+   * @param pixels
+   * @returns {number}
+   */
+  pxToWeight(weights, pixels) {
+    const totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+    const spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+    return (100 * pixels) / spaceLeftForPanels;
+  }
+
+  /**
+   * Calculate the precise sizes and offsets using the desired weights, the dom container size,
+   * and the size taken up by the dividers
+   *
+   * @param weights
+   * @returns {{sizes: Array, offsets: Array}}
+   */
+  calcSizesAndOffsets(weights) {
+    weights = weights || this.weights;
+    const offsets = [];
+    const sizes = [];
+    for (let i = 0; i < weights.length; i++) {
+      const totalDividerSizeSoFar = i * this.dividerSize;
+      const sizeInPx = this.weightToPx(weights, i);
+      offsets.push(i === 0 ? 0 : (_.sum(sizes) + totalDividerSizeSoFar));
+      sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
     }
+    return { sizes: sizes, offsets: offsets };
+  }
 
-    //////
-    // Properties
-    //////
-    /**
-     * Gets the weights for each panel. This prefers this.props.weights, falling
-     * through to this.state.weights then this.props.defaultWeights.
-     *
-     * An Error is thrown if no weights are specified.
-     */
-    get weights() {
-        let weights = null;
-        if (this.props.weights && this.props.weights.length) {
-            weights = this.props.weights;
-        }
-        else if (this.state.weights && this.state.weights.length) {
-            weights = this.state.weights;
-        }
-        else if (this.props.defaultWeights && this.props.defaultWeights.length) {
-            weights = this.props.defaultWeights;
-        }
-        else {
-            throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
-        }
-        return this.padOrTruncateWeights(weights);
+  /**
+   * Recalculates the size of each panel according to the weights, taking into
+   * account the space used by the dividers then updates this.state.sizes
+   * and this.state.offsets.
+   */
+  updateSizes(weights) {
+    const sizesAndOffsets = this.calcSizesAndOffsets(weights);
+    this.setState(sizesAndOffsets);
+  }
+
+  /**
+   * Make up for too few or too many child elements by padding or truncating the weights
+   * Return a new array of weights
+   *
+   * @param originalWeights
+   * @returns {*}
+   */
+  padOrTruncateWeights(originalWeights, children = this.props.children) {
+    const weights = _.clone(originalWeights);
+    const numChildren = React.Children.count(children);
+    if (weights.length < numChildren) {
+      const minWeight = this.pxToWeight(weights, this.props.minPanelSize);
+      console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
+        `but there are ${numChildren} subpanels; using ${minWeight} for the ` +
+        `remaining subpanels`);
+      while (weights.length < numChildren) {
+        weights.push(minWeight);
+      }
+      return weights;
+    } else if (weights.length > numChildren) {
+      console.warn(`SplitPanel: ${weights.length} weights specified but ` +
+        `there are only ${numChildren} subpanels; ignoring additional weights`);
+      return weights.splice(0, numChildren);
     }
-
-    get cursorPositionProperty() {
-        return this.props.direction == "horizontal" ? "clientX" : "clientY";
-    }
-
-    get cssSizeProperty() {
-        return this.props.direction == "horizontal" ? "width" : "height";
-    }
-
-    get cssOffsetProperty() {
-        return this.props.direction == "horizontal" ? "left" : "top";
-    }
-
-    get domSizeProperty() {
-        return this.props.direction == "horizontal" ?
-            "clientWidth" : "clientHeight";
-    }
-
-    get dividerSize() {
-        // During the initial render we can't calculate this, so default to 5px.
-        // A fresh render is forced after the component is mounted to it doesn't
-        // matter.
-        if (this.refs["divider-0"]) {
-            return this.refs["divider-0"][this.domSizeProperty];
-        }
-        else {
-            return 5;
-        }
-    }
-
-    get sizes() {
-        const numChildren = React.Children.count(this.props.children);
-        if (this.state.sizes.length == numChildren) {
-            return this.state.sizes;
-        }
-        else {
-            // XXX: We can't calculate the sizes until the component has been rendered
-            // at least once (so we can't just call this.updateSizes() here) because
-            // we need to obtain the divider size from the DOM.
-            // Instead we say that all the panels are at the minimum size and hope
-            // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
-            // this is.
-            return _.fill(new Array(numChildren), this.props.minPanelSize);
-        }
-    }
-
-    get offsets() {
-        const numChildren = React.Children.count(this.props.children);
-        if (this.state.offsets.length == numChildren) {
-            return this.state.offsets;
-        }
-        else {
-            // See the comment in `get sizes()`. The same applies here.
-            return _.fill(new Array(numChildren), 0);
-        }
-    }
-
-    //////
-    // Event Handlers
-    //////
-    onResizeHackObjectLoad() {
-        this.refs.resizeHackObject.contentDocument.defaultView.addEventListener(
-            "resize", () => this.updateSizes());
-    }
-
-    onDividerMouseDown(e, dividerIndex) {
-        const newState = {
-            activeDividerIndex: dividerIndex,
-            lastCursorPosition: e[this.cursorPositionProperty],
-        };
-        this.setState(newState);
-    }
-
-    onMouseUp() {
-        //Adjust any messed up state at this point
-        //So they can drag around as much as they want, and state will get out of whack
-        //But as soon as they let go it'll fix itself
-        const mouseIsDown = this.state.activeDividerIndex !== -1;
-        const weights = this.weights;
-        if (mouseIsDown && this.props.doAdjustmentOnMouseUp && weights) {
-            const adjustedWeights = this.adjust(weights);
-            this.emitWeightChange(adjustedWeights);
-        }
-
-        this.setState({ activeDividerIndex: -1 });
-    }
-
-    onMouseMove(e) {
-        if (this.state.activeDividerIndex == -1) return;
-        // If moving backwards (left or up) grow the next panel by taking space
-        // from the previous one. If moving forwards (right or down) grow the
-        // previous panel by taking space from the next.
-        //
-        // Horizontal: <previous>|<next>
-        // Vertical:
-        //  <previous>
-        //  ----------
-        //  <next>
-        const prevIndex = this.state.activeDividerIndex;
-        const nextIndex = prevIndex + 1;
-        // First obtain the size difference, rounding it down to a multiple of
-        // the step size...
-        const diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
-        const steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
-        if (steppedDiff == 0) {
-            // No change.
-            return;
-        }
-        // ...then make it proportional to the total weight rather than the
-        // container size.
-        const weights = this.weights;
-        const weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _.sum(weights);
-
-        // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
-        const weightPrev = weights[prevIndex];
-        const weightNext = weights[nextIndex];
-        const minWeight = this.pxToWeight(weights, this.props.minPanelSize);
-
-        function weightViolated(weight, minWeight, directionIsWrong) {
-            return (weight <= minWeight) && directionIsWrong;
-        }
-
-        //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
-        const prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
-
-        //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
-        const nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
-
-        // console.log("prevWeightViolated", prevWeightViolated);
-        // console.log("nextWeightViolated", nextWeightViolated);
-
-        if (this.props.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
-            return;
-        }
-
-        // If weightDiff is negative we're moving backwards, so this will shrink
-        // <previous> and grow <next>. Otherwise, we're moving forwards and
-        // <previous> will grow while <next> shrinks.
-        weights[prevIndex] += weightDiff;
-        weights[nextIndex] -= weightDiff;
-
-        if (this.props.doAdjustmentOnMouseMove) {
-            const adjustedWeights = this.adjust(weights);
-            this.emitWeightChange(adjustedWeights);
-        } else {
-            this.emitWeightChange(weights);
-        }
-        const newState = {
-            // We subtract the portion of the difference that we discarded to avoid
-            // accumulating rounding errors resulting in the cursor and divider
-            // positions drifting apart.
-            lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
-        };
-        this.setState(newState);
-    }
-
-    //////
-    // Event Emitters
-    //////
-    emitWeightChange(newWeights) {
-        // Only set weights on the state if we don't expect the parent to
-        // accept/reject the new weights by updating this.props.weights.
-        if (this.props.defaultWeights && this.props.defaultWeights.length) {
-            this.setState({ weights: newWeights }, () => this.updateSizes());
-        }
-        // Notify the parent that we'd like to change the weights.
-        if (this.props.onWeightChange) {
-            this.props.onWeightChange(newWeights);
-        }
-    }
-
-    //////
-    // Utilities
-    //////
-
-
-    /**
-     * Caution, mutating params
-     *
-     * @param sizes
-     * @param adjustmentNeeded
-     */
-    adjustMaxDown(sizes, adjustmentNeeded) {
-        let maxIndex = 0;
-        let maxPanelSize = sizes[0];
-        for (let i = 0; i < sizes.length; i++) {
-            if (sizes[i] > maxPanelSize) {
-                maxPanelSize = sizes[i];
-                maxIndex = i;
-            }
-        }
-        sizes[maxIndex] -= adjustmentNeeded;
-    }
-    adjustMinUp(sizes, adjustmentNeeded) {
-        let minIndex = 0;
-        let minPanelSize = sizes[0];
-        for (let i = 0; i < sizes.length; i++) {
-            if (sizes[i] < minPanelSize) {
-                minPanelSize = sizes[i];
-                minIndex = i;
-            }
-        }
-        sizes[minIndex] += adjustmentNeeded;
-    }
-
-    adjust(weights) {
-        //correct for sizes that got too big or too small
-        const sizesAndOffsets = this.calcSizesAndOffsets(weights);
-        const sizes = sizesAndOffsets.sizes;
-        // const offsets = sizesAndOffsets.offsets;
-        const sumOfSizes = _.sum(sizes);
-        const domContainerSize = this.refs.self[this.domSizeProperty];
-        const expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
-        const diff = sumOfSizes - expectedSumOfSizes;
-
-        if (diff > 0) {
-            // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
-            this.adjustMaxDown(sizes, diff);
-            return _.map(sizes, (size) => {
-                return size / expectedSumOfSizes * 100;
-            });
-        } else if (diff < 0) {
-            const absDiff = -diff;
-            // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
-            this.adjustMinUp(sizes, absDiff);
-            return _.map(sizes, (size) => {
-                return size / expectedSumOfSizes * 100;
-            });
-        }
-
-        return weights;
-    }
-
-    /**
-     * Return the amount of pixels this panel should take up
-     * Take into account the number of weights, and the space that the dividers take up
-     *
-     * Example
-     *   There are 4 weights, and the current one is 27%
-     *   The container is 1000px, and the dividers are 5px
-     *   4 weights means 3 dividers. The total space they take up is then 15px
-     *   The total amount of pixels that the panels themselves can take up is 1000px - 15px = 985px
-     *   27% of 985px is 265.95px
-     *
-     * @param weights
-     * @param index
-     * @returns {number}
-     */
-    weightToPx(weights, index) {
-        // Should always be 100, todo consider validating here
-        const totalWeight = _.sum(weights);
-
-        // The current weight's proportion of the entire container (so 27% becomes 0.27)
-        const proportion = weights[index] / totalWeight;
-
-        const totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
-
-        const spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
-
-        return proportion * spaceLeftForPanels;
-    }
-
-    /**
-     * Return the weight that this amount of pixels corresponds to
-     *
-     * @param weights
-     * @param pixels
-     * @returns {number}
-     */
-    pxToWeight(weights, pixels) {
-        const totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
-
-        const spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
-
-        return (100 * pixels) / spaceLeftForPanels;
-    }
-
-    calcSizesAndOffsets(weights, children) {
-        weights = weights || this.weights;
-        weights = this.padOrTruncateWeights(weights, children);
-        const offsets = [];
-        const sizes = [];
-        for (let i = 0; i < weights.length; i++) {
-            const totalDividerSizeSoFar = i * this.dividerSize;
-            const sizeInPx = this.weightToPx(weights, i);
-            offsets.push(i === 0 ? 0 : (_.sum(sizes) + totalDividerSizeSoFar));
-            sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
-        }
-        return { sizes: sizes, offsets: offsets };
-    }
-
-    /**
-     * Recalculates the size of each panel according to the weights, taking into
-     * account the space used by the dividers then updates this.state.sizes
-     * and this.state.offsets.
-     */
-    updateSizes(weights, children) {
-        const sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
-        // console.log("sizesAndOffsets", sizesAndOffsets);
-        this.setState(sizesAndOffsets);
-    }
-
-    /**
-     * Caution, mutating params
-     *
-     * @param weights
-     * @returns {*}
-     */
-    padOrTruncateWeights(weights, children = this.props.children) {
-        return weights;
-        // console.log("padOrTruncateWeights");
-        // console.log("weights", weights);
-        // console.log("children", children);
-        // const numChildren = React.Children.count(children);
-        // if (weights.length < numChildren) {
-        //   const min = Math.max(_.min(weights), this.props.minPanelSize);
-        //   console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
-        //     `but there are ${numChildren} subpanels; using ${min} for the ` +
-        //     `remaining subpanels`);
-        //   while (weights.length < numChildren) {
-        //     weights.push(min);
-        //   }
-        // }
-        // else if (weights.length > numChildren) {
-        //   console.warn(`SplitPanel: ${weights.length} weights specified but ` +
-        //     `there are only ${numChildren} subpanels; ignoring additional weights`);
-        //   weights = weights.splice(0, numChildren);
-        // }
-        // return weights;
-    }
+    return weights;
+  }
 }

--- a/src/SplitPanel.jsx
+++ b/src/SplitPanel.jsx
@@ -63,12 +63,57 @@ export default class SplitPanel extends React.Component {
          * Default: 1
          */
         stepSize: React.PropTypes.number,
+
+        /**
+         * Bool that controls adjustment on mouse up functionality
+         *
+         * Used to adjust the weights after a fast mousemove by the user
+         * Without it they may start to exceed the dimensions of the container
+         *
+         * Default: true
+         */
+        doAdjustmentOnMouseUp: React.PropTypes.bool,
+
+        /**
+         * Bool that controls exit on violation during mouse move functionality
+         *
+         * During the mouse move, if the minPanelSize is violated,
+         * Don't go through with the state change
+         *
+         * Default: true
+         */
+        exitMouseMoveOnViolation: React.PropTypes.bool,
+
+        /**
+         * Bool that controls adjustment on componentWillReceiveProps
+         *
+         * Used to adjust the weights when getting new props
+         *
+         * Default: true
+         */
+        adjustOnReceiveProps: React.PropTypes.bool,
+
+        /**
+         * Bool that controls adjustment on mouse move functionality
+         *
+         * Used to adjust the weights during a fast mousemove by the user
+         * Without it they may start to exceed the dimensions of the container
+         * This one is a bit risky since the action is in the middle of happening
+         * Optional and not recommended unless you're getting better results with it
+         *
+         * Default: false
+         */
+        doAdjustmentOnMouseMove: React.PropTypes.bool
     };
 
     static defaultProps = {
         direction: "horizontal",
         minPanelSize: 25,
         stepSize: 1,
+        doAdjustmentOnMouseUp: true,
+        exitMouseMoveOnViolation: true,
+        adjustOnReceiveProps: true,
+        doAdjustmentOnMouseMove: false
     };
 
     constructor() {
@@ -97,10 +142,6 @@ export default class SplitPanel extends React.Component {
         // componentWillUnmount.
         this.onMouseMove = this.onMouseMove.bind(this);
         this.onMouseUp = this.onMouseUp.bind(this);
-        this.doAdjustmentOnMouseUp = true;
-        this.exitMouseMoveOnViolation = true;
-        this.adjustOnReceiveProps = true;
-        this.doAdjustmentOnMouseMove = false; //Not recommended, seems to cause incorrect results
     }
 
     render() {
@@ -154,7 +195,7 @@ export default class SplitPanel extends React.Component {
     //////
     componentWillReceiveProps(newProps) {
         if (newProps.weights) {
-            const weights = this.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
+            const weights = this.props.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
             // console.log("componentWillReceiveProps updating with weights: ", weights);
             this.updateSizes(weights);
         }
@@ -279,7 +320,7 @@ export default class SplitPanel extends React.Component {
         //But as soon as they let go it'll fix itself
         const mouseIsDown = this.state.activeDividerIndex !== -1;
         const weights = this.weights;
-        if (mouseIsDown && this.doAdjustmentOnMouseUp && weights) {
+        if (mouseIsDown && this.props.doAdjustmentOnMouseUp && weights) {
             const adjustedWeights = this.adjust(weights);
             this.emitWeightChange(adjustedWeights);
         }
@@ -331,7 +372,7 @@ export default class SplitPanel extends React.Component {
         // console.log("prevWeightViolated", prevWeightViolated);
         // console.log("nextWeightViolated", nextWeightViolated);
 
-        if (this.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
+        if (this.props.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
             return;
         }
 
@@ -341,7 +382,7 @@ export default class SplitPanel extends React.Component {
         weights[prevIndex] += weightDiff;
         weights[nextIndex] -= weightDiff;
 
-        if (this.doAdjustmentOnMouseMove) {
+        if (this.props.doAdjustmentOnMouseMove) {
             const adjustedWeights = this.adjust(weights);
             this.emitWeightChange(adjustedWeights);
         } else {
@@ -498,6 +539,7 @@ export default class SplitPanel extends React.Component {
      */
     updateSizes(weights, children) {
         const sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
+        // console.log("sizesAndOffsets", sizesAndOffsets);
         this.setState(sizesAndOffsets);
     }
 

--- a/src/SplitPanel.jsx
+++ b/src/SplitPanel.jsx
@@ -17,495 +17,516 @@ import _ from "lodash";
  * used for all remaining elements. Any additional weights will be ignored.
  */
 export default class SplitPanel extends React.Component {
-  static propTypes = {
-    /**
-     * The direction to layout subpanels. One of "horizontal" or "vertical".
-     *
-     * Default: horizontal
-     */
-    direction: React.PropTypes.oneOf(["horizontal", "vertical"]),
+    static propTypes = {
+        /**
+         * The direction to layout subpanels. One of "horizontal" or "vertical".
+         *
+         * Default: horizontal
+         */
+        direction: React.PropTypes.oneOf(["horizontal", "vertical"]),
 
-    /**
-     * The minimum size (in pixels) of a subpanel. The divider will stop
-     * abruptly if the user attempts to shrink a subpanel below this size.
-     *
-     * Default: 25
-     */
-    minPanelSize: React.PropTypes.number,
+        /**
+         * The minimum size (in pixels) of a subpanel. The divider will stop
+         * abruptly if the user attempts to shrink a subpanel below this size.
+         *
+         * Default: 25
+         */
+        minPanelSize: React.PropTypes.number,
 
-    /**
-     * Called whenever a subpanel is resized.
-     *
-     * You should update `weights` in response to this event unless you're
-     * using `defaultWeights`.
-     */
-    onWeightChange: React.PropTypes.func,
+        /**
+         * Called whenever a subpanel is resized.
+         *
+         * You should update `weights` in response to this event unless you're
+         * using `defaultWeights`.
+         */
+        onWeightChange: React.PropTypes.func,
 
-    /**
-     * The weights of each subpanel. If you're using this property you must
-     * manually update this prop in response to `onWeightChange` otherwise
-     * the subpanels will not resize.
-     */
-    weights: React.PropTypes.arrayOf(React.PropTypes.number),
+        /**
+         * The weights of each subpanel. If you're using this property you must
+         * manually update this prop in response to `onWeightChange` otherwise
+         * the subpanels will not resize.
+         */
+        weights: React.PropTypes.arrayOf(React.PropTypes.number),
 
-    /**
-     * The default weights to use when you are not managing the weights
-     * manually via the `weights` and `onWeightChange` props.
-     */
-    defaultWeights: React.PropTypes.arrayOf(React.PropTypes.number),
+        /**
+         * The default weights to use when you are not managing the weights
+         * manually via the `weights` and `onWeightChange` props.
+         */
+        defaultWeights: React.PropTypes.arrayOf(React.PropTypes.number),
 
-    /**
-     * The resize step size in pixels.
-     *
-     * Useful if you have monospaced text and you want to ensure the panel
-     * is resized in increments of one character width.
-     *
-     * Default: 1
-     */
-    stepSize: React.PropTypes.number,
-  };
-
-  static defaultProps = {
-    direction: "horizontal",
-    minPanelSize: 25,
-    stepSize: 1,
-  };
-
-  constructor() {
-    super();
-
-    this.state = {
-      // The last position of the cursor. Used by onMouseMove to calculate
-      // relative changes in divider position.
-      lastCursorPosition: 0,
-      // Sizes of the subpanels taking into account the weights and divider
-      // size.
-      sizes: [],
-      // Offsets of each subpanel.
-      offsets: [],
-      // The index of the divider currently being dragged by the user.
-      activeDividerIndex: -1,
+        /**
+         * The resize step size in pixels.
+         *
+         * Useful if you have monospaced text and you want to ensure the panel
+         * is resized in increments of one character width.
+         *
+         * Default: 1
+         */
+        stepSize: React.PropTypes.number,
     };
 
-    // Bind event listeners in advance.
-    this.onDividerMouseDown = this.onDividerMouseDown.bind(this);
-    // These two are attached to `window` because sometimes due to glitches we
-    // can't do very much about we'll be unable to move the divider in time to
-    // keep up with the mouse cursor, but we still need to move the divider to
-    // catch up and to release it when the user releases the divider.
-    // N.B. These are attached in componentDidMount and detached in
-    // componentWillUnmount.
-    this.onMouseMove = this.onMouseMove.bind(this);
-    this.onMouseUp = this.onMouseUp.bind(this);
-    this.doAdjustmentOnMouseUp = true;
-    this.exitMouseMoveOnViolation = true;
-    this.adjustOnReceiveProps = true;
-    this.doAdjustmentOnMouseMove = false;
-  }
+    static defaultProps = {
+        direction: "horizontal",
+        minPanelSize: 25,
+        stepSize: 1,
+    };
 
-  render() {
+    constructor() {
+        super();
 
-    // Create a sized splitPanelItem with a divider for each child, except...
-    const childrenWithDividers = [];
-    const children = React.Children.toArray(this.props.children);
-    for (let i = 0; i < children.length; i++) {
-      const style = {
-        [this.cssSizeProperty]: this.sizes[i],
-        [this.cssOffsetProperty]: this.offsets[i],
-      };
-
-      childrenWithDividers.push(<div key={`panel-${i}`}
-                                     className="split-panel-item"
-                                     style={style}>{children[i]}</div>);
-
-      // ...don't add a divider if it's the last panel.
-      if (i < children.length - 1) {
-        const dividerStyle = {
-          [this.cssOffsetProperty]: this.offsets[i + 1] - this.dividerSize,
+        this.state = {
+            // The last position of the cursor. Used by onMouseMove to calculate
+            // relative changes in divider position.
+            lastCursorPosition: 0,
+            // Sizes of the subpanels taking into account the weights and divider
+            // size.
+            sizes: [],
+            // Offsets of each subpanel.
+            offsets: [],
+            // The index of the divider currently being dragged by the user.
+            activeDividerIndex: -1,
         };
-        childrenWithDividers.push(<div
-          key={`divider-${i}`} ref={`divider-${i}`}
-          className="split-panel-divider"
-          style={dividerStyle}
-          onMouseDown={e => this.onDividerMouseDown(e, i)}>
-        </div>);
-      }
+
+        // Bind event listeners in advance.
+        this.onDividerMouseDown = this.onDividerMouseDown.bind(this);
+        // These two are attached to `window` because sometimes due to glitches we
+        // can't do very much about we'll be unable to move the divider in time to
+        // keep up with the mouse cursor, but we still need to move the divider to
+        // catch up and to release it when the user releases the divider.
+        // N.B. These are attached in componentDidMount and detached in
+        // componentWillUnmount.
+        this.onMouseMove = this.onMouseMove.bind(this);
+        this.onMouseUp = this.onMouseUp.bind(this);
+        this.doAdjustmentOnMouseUp = true;
+        this.exitMouseMoveOnViolation = true;
+        this.adjustOnReceiveProps = true;
+        this.doAdjustmentOnMouseMove = false; //Not recommended, seems to cause incorrect results
     }
 
-    // Because elements don't have a resize event we create an <object> with
-    // no content and filling the entire panel. When this object's
-    // contentDocument.resize event fires we know to update the sizes of all
-    // the subpanels. :-)
-    const resizeHackObject = <object className="split-panel-resize-hack-object"
-                                     ref="resizeHackObject"
-                                     type="text/html">
-    </object>;
-    const klass = classNames("split-panel", this.props.direction, {
-      "split-panel-resizing": this.state.activeDividerIndex != -1,
-    });
-    return <div ref="self" className={klass}>
-      {resizeHackObject}
-      {childrenWithDividers}
-    </div>;
-  }
+    render() {
 
-  //////
-  // Component Lifecycle
-  //////
-  componentWillReceiveProps(newProps) {
-    if (newProps.weights) {
-      const weights = this.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
-      // console.log("componentWillReceiveProps updating with weights: ", weights);
-      this.updateSizes(weights);
-    }
-  }
+        // Create a sized splitPanelItem with a divider for each child, except...
+        const childrenWithDividers = [];
+        const children = React.Children.toArray(this.props.children);
+        for (let i = 0; i < children.length; i++) {
+            const style = {
+                [this.cssSizeProperty]: this.sizes[i],
+                [this.cssOffsetProperty]: this.offsets[i],
+            };
 
-  componentDidMount() {
-    window.addEventListener("mouseup", this.onMouseUp);
-    window.addEventListener("mousemove", this.onMouseMove);
-    // We do this here because we can't guarantee that the event handler will be
-    // added before data is assigned if we do it in the JSX.
-    this.refs.resizeHackObject.addEventListener("load", () => this.onResizeHackObjectLoad());
-    this.refs.resizeHackObject.data = "about:blank";
-    this.updateSizes();
-  }
+            childrenWithDividers.push(<div key={`panel-${i}`}
+                                           className="split-panel-item"
+                                           style={style}>{children[i]}</div>);
 
-  componentWillUnmount() {
-    window.removeEventListener("mouseup", this.onMouseUp);
-    window.removeEventListener("mousemove", this.onMouseMove);
-  }
+            // ...don't add a divider if it's the last panel.
+            if (i < children.length - 1) {
+                const dividerStyle = {
+                    [this.cssOffsetProperty]: this.offsets[i + 1] - this.dividerSize,
+                };
+                childrenWithDividers.push(<div
+                    key={`divider-${i}`} ref={`divider-${i}`}
+                    className="split-panel-divider"
+                    style={dividerStyle}
+                    onMouseDown={e => this.onDividerMouseDown(e, i)}>
+                </div>);
+            }
+        }
 
-  //////
-  // Properties
-  //////
-  /**
-   * Gets the weights for each panel. This prefers this.props.weights, falling
-   * through to this.state.weights then this.props.defaultWeights.
-   *
-   * An Error is thrown if no weights are specified.
-   */
-  get weights() {
-    let weights = null;
-    if (this.props.weights && this.props.weights.length) {
-      weights = this.props.weights;
-    }
-    else if (this.state.weights && this.state.weights.length) {
-      weights = this.state.weights;
-    }
-    else if (this.props.defaultWeights && this.props.defaultWeights.length) {
-      weights = this.props.defaultWeights;
-    }
-    else {
-      throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
-    }
-    return this.padOrTruncateWeights(weights);
-  }
-
-  get cursorPositionProperty() {
-    return this.props.direction == "horizontal" ? "clientX" : "clientY";
-  }
-
-  get cssSizeProperty() {
-    return this.props.direction == "horizontal" ? "width" : "height";
-  }
-
-  get cssOffsetProperty() {
-    return this.props.direction == "horizontal" ? "left" : "top";
-  }
-
-  get domSizeProperty() {
-    return this.props.direction == "horizontal" ?
-      "clientWidth" : "clientHeight";
-  }
-
-  get dividerSize() {
-    // During the initial render we can't calculate this, so default to 5px.
-    // A fresh render is forced after the component is mounted to it doesn't
-    // matter.
-    if (this.refs["divider-0"]) {
-      return this.refs["divider-0"][this.domSizeProperty];
-    }
-    else {
-      return 5;
-    }
-  }
-
-  get sizes() {
-    const numChildren = React.Children.count(this.props.children);
-    if (this.state.sizes.length == numChildren) {
-      return this.state.sizes;
-    }
-    else {
-      // XXX: We can't calculate the sizes until the component has been rendered
-      // at least once (so we can't just call this.updateSizes() here) because
-      // we need to obtain the divider size from the DOM.
-      // Instead we say that all the panels are at the minimum size and hope
-      // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
-      // this is.
-      return _.fill(new Array(numChildren), this.props.minPanelSize);
-    }
-  }
-
-  get offsets() {
-    const numChildren = React.Children.count(this.props.children);
-    if (this.state.offsets.length == numChildren) {
-      return this.state.offsets;
-    }
-    else {
-      // See the comment in `get sizes()`. The same applies here.
-      return _.fill(new Array(numChildren), 0);
-    }
-  }
-
-  //////
-  // Event Handlers
-  //////
-  onResizeHackObjectLoad() {
-    this.refs.resizeHackObject.contentDocument.defaultView.addEventListener(
-      "resize", () => this.updateSizes());
-  }
-
-  onDividerMouseDown(e, dividerIndex) {
-    const newState = {
-      activeDividerIndex: dividerIndex,
-      lastCursorPosition: e[this.cursorPositionProperty],
-    };
-    this.setState(newState);
-  }
-
-  onMouseUp() {
-    //Adjust any messed up state at this point
-    //So they can drag around as much as they want, and state will get out of whack
-    //But as soon as they let go it'll fix itself
-    const mouseIsDown = this.state.activeDividerIndex !== -1;
-    const weights = this.weights;
-    if (mouseIsDown && this.doAdjustmentOnMouseUp && weights) {
-      const adjustedWeights = this.adjust(weights);
-      this.emitWeightChange(adjustedWeights);
+        // Because elements don't have a resize event we create an <object> with
+        // no content and filling the entire panel. When this object's
+        // contentDocument.resize event fires we know to update the sizes of all
+        // the subpanels. :-)
+        const resizeHackObject = <object className="split-panel-resize-hack-object"
+                                         ref="resizeHackObject"
+                                         type="text/html">
+        </object>;
+        const klass = classNames("split-panel", this.props.direction, {
+            "split-panel-resizing": this.state.activeDividerIndex != -1,
+        });
+        return <div ref="self" className={klass}>
+            {resizeHackObject}
+            {childrenWithDividers}
+        </div>;
     }
 
-    this.setState({ activeDividerIndex: -1 });
-  }
-
-  onMouseMove(e) {
-    if (this.state.activeDividerIndex == -1) return;
-    // If moving backwards (left or up) grow the next panel by taking space
-    // from the previous one. If moving forwards (right or down) grow the
-    // previous panel by taking space from the next.
-    //
-    // Horizontal: <previous>|<next>
-    // Vertical:
-    //  <previous>
-    //  ----------
-    //  <next>
-    const prevIndex = this.state.activeDividerIndex;
-    const nextIndex = prevIndex + 1;
-    // First obtain the size difference, rounding it down to a multiple of
-    // the step size...
-    const diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
-    const steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
-    if (steppedDiff == 0) {
-      // No change.
-      return;
-    }
-    // ...then make it proportional to the total weight rather than the
-    // container size.
-    const weights = this.weights;
-    const weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _.sum(weights);
-
-    // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
-    const weightPrev = weights[prevIndex];
-    const weightNext = weights[nextIndex];
-    const minWeight = this.pxToWeight(weights, this.props.minPanelSize);
-
-    function weightViolated(weight, minWeight, directionIsWrong) {
-      return (weight <= minWeight) && directionIsWrong;
+    //////
+    // Component Lifecycle
+    //////
+    componentWillReceiveProps(newProps) {
+        if (newProps.weights) {
+            const weights = this.adjustOnReceiveProps ? this.adjust(newProps.weights) : newProps.weights;
+            // console.log("componentWillReceiveProps updating with weights: ", weights);
+            this.updateSizes(weights);
+        }
     }
 
-    //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
-    const prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
-
-    //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
-    const nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
-
-    // console.log("prevWeightViolated", prevWeightViolated);
-    // console.log("nextWeightViolated", nextWeightViolated);
-
-    if (this.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
-      return;
+    componentDidMount() {
+        window.addEventListener("mouseup", this.onMouseUp);
+        window.addEventListener("mousemove", this.onMouseMove);
+        // We do this here because we can't guarantee that the event handler will be
+        // added before data is assigned if we do it in the JSX.
+        this.refs.resizeHackObject.addEventListener("load", () => this.onResizeHackObjectLoad());
+        this.refs.resizeHackObject.data = "about:blank";
+        this.updateSizes();
     }
 
-    // If weightDiff is negative we're moving backwards, so this will shrink
-    // <previous> and grow <next>. Otherwise, we're moving forwards and
-    // <previous> will grow while <next> shrinks.
-    weights[prevIndex] += weightDiff;
-    weights[nextIndex] -= weightDiff;
-
-    if (this.doAdjustmentOnMouseMove) {
-      const adjustedWeights = this.adjust(weights);
-      this.emitWeightChange(adjustedWeights);
-    } else {
-      this.emitWeightChange(weights);
-    }
-    const newState = {
-      // We subtract the portion of the difference that we discarded to avoid
-      // accumulating rounding errors resulting in the cursor and divider
-      // positions drifting apart.
-      lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
-    };
-    this.setState(newState);
-  }
-
-  //////
-  // Event Emitters
-  //////
-  emitWeightChange(newWeights) {
-    // Only set weights on the state if we don't expect the parent to
-    // accept/reject the new weights by updating this.props.weights.
-    if (this.props.defaultWeights && this.props.defaultWeights.length) {
-      this.setState({ weights: newWeights }, () => this.updateSizes());
-    }
-    // Notify the parent that we'd like to change the weights.
-    if (this.props.onWeightChange) {
-      this.props.onWeightChange(newWeights);
-    }
-  }
-
-  //////
-  // Utilities
-  //////
-
-
-  /**
-   * Caution, mutating params
-   *
-   * @param sizes
-   * @param adjustmentNeeded
-   */
-  adjustMaxDown(sizes, adjustmentNeeded) {
-    let maxIndex = 0;
-    let maxPanelSize = sizes[0];
-    for (let i = 0; i < sizes.length; i++) {
-      if (sizes[i] > maxPanelSize) {
-        maxPanelSize = sizes[i];
-        maxIndex = i;
-      }
-    }
-    sizes[maxIndex] -= adjustmentNeeded;
-  }
-  adjustMinUp(sizes, adjustmentNeeded) {
-    let minIndex = 0;
-    let minPanelSize = sizes[0];
-    for (let i = 0; i < sizes.length; i++) {
-      if (sizes[i] < minPanelSize) {
-        minPanelSize = sizes[i];
-        minIndex = i;
-      }
-    }
-    sizes[minIndex] += adjustmentNeeded;
-  }
-
-  adjust(weights) {
-    //correct for sizes that got too big or too small
-    const sizesAndOffsets = this.calcSizesAndOffsets(weights);
-    const sizes = sizesAndOffsets.sizes;
-    // const offsets = sizesAndOffsets.offsets;
-    const sumOfSizes = _.sum(sizes);
-    const domContainerSize = this.refs.self[this.domSizeProperty];
-    const expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
-    const diff = sumOfSizes - expectedSumOfSizes;
-
-    if (diff > 0) {
-      // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
-      this.adjustMaxDown(sizes, diff);
-      return _.map(sizes, (size) => {
-        return size / expectedSumOfSizes * 100;
-      });
-    } else if (diff < 0) {
-      const absDiff = -diff;
-      // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
-      this.adjustMinUp(sizes, absDiff);
-      return _.map(sizes, (size) => {
-        return size / expectedSumOfSizes * 100;
-      });
+    componentWillUnmount() {
+        window.removeEventListener("mouseup", this.onMouseUp);
+        window.removeEventListener("mousemove", this.onMouseMove);
     }
 
-    return weights;
-  }
-
-  weightToPx(weights, index) {
-    const totalWeight = _.sum(weights);
-    // Total space taken by the dividers spread equally across all panels.
-    const dividerCompensation = this.dividerSize * (weights.length - 1) / weights.length;
-    const proportion = weights[index] / totalWeight;
-    return proportion * this.refs.self[this.domSizeProperty] - dividerCompensation;
-  }
-
-  pxToWeight(weights, pixels) {
-    // Total space taken by the dividers spread equally across all panels.
-    const dividerCompensation = this.dividerSize * (weights.length - 1) / weights.length;
-    return 100 * ((pixels + dividerCompensation) / this.refs.self[this.domSizeProperty]);
-  }
-
-  calcSizesAndOffsets(weights, children) {
-    // console.log("calcSizesAndOffsets");
-    // console.log("weights", weights);
-    // console.log("children", children);
-    weights = weights || this.weights;
-    weights = this.padOrTruncateWeights(weights, children);
-    const totalWeight = _.sum(weights);
-    // Total space taken by the dividers spread equally across all panels.
-    const dividerCompensation = this.dividerSize * (weights.length - 1) / weights.length;
-    const offsets = [];
-    const sizes = [];
-    for (let i = 0; i < weights.length; i++) {
-      //TODO fix the math here, offsets start to be further and further off as the number of panes grows
-      offsets.push(_.sum(sizes) + 2 * dividerCompensation * i);
-      const sizeInPx = this.weightToPx(weights, i);
-      sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
+    //////
+    // Properties
+    //////
+    /**
+     * Gets the weights for each panel. This prefers this.props.weights, falling
+     * through to this.state.weights then this.props.defaultWeights.
+     *
+     * An Error is thrown if no weights are specified.
+     */
+    get weights() {
+        let weights = null;
+        if (this.props.weights && this.props.weights.length) {
+            weights = this.props.weights;
+        }
+        else if (this.state.weights && this.state.weights.length) {
+            weights = this.state.weights;
+        }
+        else if (this.props.defaultWeights && this.props.defaultWeights.length) {
+            weights = this.props.defaultWeights;
+        }
+        else {
+            throw new Error("SplitPanel: You must set a 'weights' or 'defaultWeights' prop");
+        }
+        return this.padOrTruncateWeights(weights);
     }
-    return { sizes: sizes, offsets: offsets };
-  }
 
-  /**
-   * Recalculates the size of each panel according to the weights, taking into
-   * account the space used by the dividers then updates this.state.sizes
-   * and this.state.offsets.
-   */
-  updateSizes(weights, children) {
-    // console.log("updateSizes");
-    // console.log("weights", weights);
-    // console.log("children", children);
-    const sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
-    this.setState(sizesAndOffsets);
-  }
+    get cursorPositionProperty() {
+        return this.props.direction == "horizontal" ? "clientX" : "clientY";
+    }
 
-  /**
-   * Caution, mutating params
-   *
-   * @param weights
-   * @returns {*}
-   */
-  padOrTruncateWeights(weights, children = this.props.children) {
-    return weights;
-    // console.log("padOrTruncateWeights");
-    // console.log("weights", weights);
-    // console.log("children", children);
-    // const numChildren = React.Children.count(children);
-    // if (weights.length < numChildren) {
-    //   const min = Math.max(_.min(weights), this.props.minPanelSize);
-    //   console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
-    //     `but there are ${numChildren} subpanels; using ${min} for the ` +
-    //     `remaining subpanels`);
-    //   while (weights.length < numChildren) {
-    //     weights.push(min);
-    //   }
-    // }
-    // else if (weights.length > numChildren) {
-    //   console.warn(`SplitPanel: ${weights.length} weights specified but ` +
-    //     `there are only ${numChildren} subpanels; ignoring additional weights`);
-    //   weights = weights.splice(0, numChildren);
-    // }
-    // return weights;
-  }
+    get cssSizeProperty() {
+        return this.props.direction == "horizontal" ? "width" : "height";
+    }
+
+    get cssOffsetProperty() {
+        return this.props.direction == "horizontal" ? "left" : "top";
+    }
+
+    get domSizeProperty() {
+        return this.props.direction == "horizontal" ?
+            "clientWidth" : "clientHeight";
+    }
+
+    get dividerSize() {
+        // During the initial render we can't calculate this, so default to 5px.
+        // A fresh render is forced after the component is mounted to it doesn't
+        // matter.
+        if (this.refs["divider-0"]) {
+            return this.refs["divider-0"][this.domSizeProperty];
+        }
+        else {
+            return 5;
+        }
+    }
+
+    get sizes() {
+        const numChildren = React.Children.count(this.props.children);
+        if (this.state.sizes.length == numChildren) {
+            return this.state.sizes;
+        }
+        else {
+            // XXX: We can't calculate the sizes until the component has been rendered
+            // at least once (so we can't just call this.updateSizes() here) because
+            // we need to obtain the divider size from the DOM.
+            // Instead we say that all the panels are at the minimum size and hope
+            // the initial render occurs quickly. XXX: Extra XXX to emphasise how ugly
+            // this is.
+            return _.fill(new Array(numChildren), this.props.minPanelSize);
+        }
+    }
+
+    get offsets() {
+        const numChildren = React.Children.count(this.props.children);
+        if (this.state.offsets.length == numChildren) {
+            return this.state.offsets;
+        }
+        else {
+            // See the comment in `get sizes()`. The same applies here.
+            return _.fill(new Array(numChildren), 0);
+        }
+    }
+
+    //////
+    // Event Handlers
+    //////
+    onResizeHackObjectLoad() {
+        this.refs.resizeHackObject.contentDocument.defaultView.addEventListener(
+            "resize", () => this.updateSizes());
+    }
+
+    onDividerMouseDown(e, dividerIndex) {
+        const newState = {
+            activeDividerIndex: dividerIndex,
+            lastCursorPosition: e[this.cursorPositionProperty],
+        };
+        this.setState(newState);
+    }
+
+    onMouseUp() {
+        //Adjust any messed up state at this point
+        //So they can drag around as much as they want, and state will get out of whack
+        //But as soon as they let go it'll fix itself
+        const mouseIsDown = this.state.activeDividerIndex !== -1;
+        const weights = this.weights;
+        if (mouseIsDown && this.doAdjustmentOnMouseUp && weights) {
+            const adjustedWeights = this.adjust(weights);
+            this.emitWeightChange(adjustedWeights);
+        }
+
+        this.setState({ activeDividerIndex: -1 });
+    }
+
+    onMouseMove(e) {
+        if (this.state.activeDividerIndex == -1) return;
+        // If moving backwards (left or up) grow the next panel by taking space
+        // from the previous one. If moving forwards (right or down) grow the
+        // previous panel by taking space from the next.
+        //
+        // Horizontal: <previous>|<next>
+        // Vertical:
+        //  <previous>
+        //  ----------
+        //  <next>
+        const prevIndex = this.state.activeDividerIndex;
+        const nextIndex = prevIndex + 1;
+        // First obtain the size difference, rounding it down to a multiple of
+        // the step size...
+        const diff = e[this.cursorPositionProperty] - this.state.lastCursorPosition;
+        const steppedDiff = (diff / this.props.stepSize | 0) * this.props.stepSize;
+        if (steppedDiff == 0) {
+            // No change.
+            return;
+        }
+        // ...then make it proportional to the total weight rather than the
+        // container size.
+        const weights = this.weights;
+        const weightDiff = steppedDiff / this.refs.self[this.domSizeProperty] * _.sum(weights);
+
+        // handle the case where minPanelSize is respected for the small panel, but its neighbor grows (it shouldn't)
+        const weightPrev = weights[prevIndex];
+        const weightNext = weights[nextIndex];
+        const minWeight = this.pxToWeight(weights, this.props.minPanelSize);
+
+        function weightViolated(weight, minWeight, directionIsWrong) {
+            return (weight <= minWeight) && directionIsWrong;
+        }
+
+        //the previous weight is violated when it's too small, and we're moving in the negative direction, so it's getting smaller
+        const prevWeightViolated = weightViolated(weightPrev, minWeight, weightDiff < 0);
+
+        //the next weight is violated when it's too small, and we're moving in the positive direction, so it's getting smaller
+        const nextWeightViolated = weightViolated(weightNext, minWeight, weightDiff > 0);
+
+        // console.log("prevWeightViolated", prevWeightViolated);
+        // console.log("nextWeightViolated", nextWeightViolated);
+
+        if (this.exitMouseMoveOnViolation && (prevWeightViolated || nextWeightViolated)) {
+            return;
+        }
+
+        // If weightDiff is negative we're moving backwards, so this will shrink
+        // <previous> and grow <next>. Otherwise, we're moving forwards and
+        // <previous> will grow while <next> shrinks.
+        weights[prevIndex] += weightDiff;
+        weights[nextIndex] -= weightDiff;
+
+        if (this.doAdjustmentOnMouseMove) {
+            const adjustedWeights = this.adjust(weights);
+            this.emitWeightChange(adjustedWeights);
+        } else {
+            this.emitWeightChange(weights);
+        }
+        const newState = {
+            // We subtract the portion of the difference that we discarded to avoid
+            // accumulating rounding errors resulting in the cursor and divider
+            // positions drifting apart.
+            lastCursorPosition: e[this.cursorPositionProperty] - (diff - steppedDiff)
+        };
+        this.setState(newState);
+    }
+
+    //////
+    // Event Emitters
+    //////
+    emitWeightChange(newWeights) {
+        // Only set weights on the state if we don't expect the parent to
+        // accept/reject the new weights by updating this.props.weights.
+        if (this.props.defaultWeights && this.props.defaultWeights.length) {
+            this.setState({ weights: newWeights }, () => this.updateSizes());
+        }
+        // Notify the parent that we'd like to change the weights.
+        if (this.props.onWeightChange) {
+            this.props.onWeightChange(newWeights);
+        }
+    }
+
+    //////
+    // Utilities
+    //////
+
+
+    /**
+     * Caution, mutating params
+     *
+     * @param sizes
+     * @param adjustmentNeeded
+     */
+    adjustMaxDown(sizes, adjustmentNeeded) {
+        let maxIndex = 0;
+        let maxPanelSize = sizes[0];
+        for (let i = 0; i < sizes.length; i++) {
+            if (sizes[i] > maxPanelSize) {
+                maxPanelSize = sizes[i];
+                maxIndex = i;
+            }
+        }
+        sizes[maxIndex] -= adjustmentNeeded;
+    }
+    adjustMinUp(sizes, adjustmentNeeded) {
+        let minIndex = 0;
+        let minPanelSize = sizes[0];
+        for (let i = 0; i < sizes.length; i++) {
+            if (sizes[i] < minPanelSize) {
+                minPanelSize = sizes[i];
+                minIndex = i;
+            }
+        }
+        sizes[minIndex] += adjustmentNeeded;
+    }
+
+    adjust(weights) {
+        //correct for sizes that got too big or too small
+        const sizesAndOffsets = this.calcSizesAndOffsets(weights);
+        const sizes = sizesAndOffsets.sizes;
+        // const offsets = sizesAndOffsets.offsets;
+        const sumOfSizes = _.sum(sizes);
+        const domContainerSize = this.refs.self[this.domSizeProperty];
+        const expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
+        const diff = sumOfSizes - expectedSumOfSizes;
+
+        if (diff > 0) {
+            // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
+            this.adjustMaxDown(sizes, diff);
+            return _.map(sizes, (size) => {
+                return size / expectedSumOfSizes * 100;
+            });
+        } else if (diff < 0) {
+            const absDiff = -diff;
+            // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
+            this.adjustMinUp(sizes, absDiff);
+            return _.map(sizes, (size) => {
+                return size / expectedSumOfSizes * 100;
+            });
+        }
+
+        return weights;
+    }
+
+    /**
+     * Return the amount of pixels this panel should take up
+     * Take into account the number of weights, and the space that the dividers take up
+     *
+     * Example
+     *   There are 4 weights, and the current one is 27%
+     *   The container is 1000px, and the dividers are 5px
+     *   4 weights means 3 dividers. The total space they take up is then 15px
+     *   The total amount of pixels that the panels themselves can take up is 1000px - 15px = 985px
+     *   27% of 985px is 265.95px
+     *
+     * @param weights
+     * @param index
+     * @returns {number}
+     */
+    weightToPx(weights, index) {
+        // Should always be 100, todo consider validating here
+        const totalWeight = _.sum(weights);
+
+        // The current weight's proportion of the entire container (so 27% becomes 0.27)
+        const proportion = weights[index] / totalWeight;
+
+        const totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+        const spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+        return proportion * spaceLeftForPanels;
+    }
+
+    /**
+     * Return the weight that this amount of pixels corresponds to
+     *
+     * @param weights
+     * @param pixels
+     * @returns {number}
+     */
+    pxToWeight(weights, pixels) {
+        const totalSpaceTakenByDividers = this.dividerSize * (weights.length - 1);
+
+        const spaceLeftForPanels = this.refs.self[this.domSizeProperty] - totalSpaceTakenByDividers;
+
+        return (100 * pixels) / spaceLeftForPanels;
+    }
+
+    calcSizesAndOffsets(weights, children) {
+        weights = weights || this.weights;
+        weights = this.padOrTruncateWeights(weights, children);
+        const offsets = [];
+        const sizes = [];
+        for (let i = 0; i < weights.length; i++) {
+            const totalDividerSizeSoFar = i * this.dividerSize;
+            const sizeInPx = this.weightToPx(weights, i);
+            offsets.push(i === 0 ? 0 : (_.sum(sizes) + totalDividerSizeSoFar));
+            sizes.push(Math.max(sizeInPx, this.props.minPanelSize));
+        }
+        return { sizes: sizes, offsets: offsets };
+    }
+
+    /**
+     * Recalculates the size of each panel according to the weights, taking into
+     * account the space used by the dividers then updates this.state.sizes
+     * and this.state.offsets.
+     */
+    updateSizes(weights, children) {
+        const sizesAndOffsets = this.calcSizesAndOffsets(weights, children);
+        this.setState(sizesAndOffsets);
+    }
+
+    /**
+     * Caution, mutating params
+     *
+     * @param weights
+     * @returns {*}
+     */
+    padOrTruncateWeights(weights, children = this.props.children) {
+        return weights;
+        // console.log("padOrTruncateWeights");
+        // console.log("weights", weights);
+        // console.log("children", children);
+        // const numChildren = React.Children.count(children);
+        // if (weights.length < numChildren) {
+        //   const min = Math.max(_.min(weights), this.props.minPanelSize);
+        //   console.warn(`SplitPanel: Only ${weights.length} weights specified ` +
+        //     `but there are ${numChildren} subpanels; using ${min} for the ` +
+        //     `remaining subpanels`);
+        //   while (weights.length < numChildren) {
+        //     weights.push(min);
+        //   }
+        // }
+        // else if (weights.length > numChildren) {
+        //   console.warn(`SplitPanel: ${weights.length} weights specified but ` +
+        //     `there are only ${numChildren} subpanels; ignoring additional weights`);
+        //   weights = weights.splice(0, numChildren);
+        // }
+        // return weights;
+    }
 }

--- a/src/SplitPanel.jsx
+++ b/src/SplitPanel.jsx
@@ -409,25 +409,25 @@ export default class SplitPanel extends React.Component {
     //correct for sizes that got too big or too small
     const sizesAndOffsets = this.calcSizesAndOffsets(weights);
     const sizes = sizesAndOffsets.sizes;
-    const offsets = sizesAndOffsets.offsets;
+    // const offsets = sizesAndOffsets.offsets;
     const sumOfSizes = _.sum(sizes);
     const domContainerSize = this.refs.self[this.domSizeProperty];
-    const expectedSumOfSizes = domContainerSize - weights.length - 1 * this.dividerSize;
+    const expectedSumOfSizes = domContainerSize - this.dividerSize * (weights.length - 1);
     const diff = sumOfSizes - expectedSumOfSizes;
-    // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
 
     if (diff > 0) {
+      // console.log("Adjusting: sumOfSizes is " + diff + " higher than expectedSumOfSizes");
       this.adjustMaxDown(sizes, diff);
-      const adjustedWeights = _.map(sizes, (size) => {
+      return _.map(sizes, (size) => {
         return size / expectedSumOfSizes * 100;
       });
-      return adjustedWeights;
     } else if (diff < 0) {
-      this.adjustMinUp(sizes, diff);
-      const adjustedWeights = _.map(sizes, (size) => {
+      const absDiff = -diff;
+      // console.log("Adjusting: sumOfSizes is " + absDiff + " lower than expectedSumOfSizes");
+      this.adjustMinUp(sizes, absDiff);
+      return _.map(sizes, (size) => {
         return size / expectedSumOfSizes * 100;
       });
-      return adjustedWeights;
     }
 
     return weights;


### PR DESCRIPTION
### Update
- The approach seems to work well in a standalone test app, and integrated into the realtime code.
- The issue with `padOrTruncateWeights` has been fixed. 
- The only outstanding issue I know of is more of an improvement, and that's allowing for different values of minPanelSize per panel. Right now you can only pass one minPanelSize, and it's applied to all of the panels.

### Prior Discussion
Pushing this up so I can refer to the branch in our main project's package.json. The approach consists of the following:
- On mousemove, check for violations of minPanelSize, and exit the function if necessary
- On mouseup, validate and adjust the sizes so that they fit in the container

This seems to work, but a few things still need to be addressed.
- `padOrTruncateWeights` was causing a bug and is commented out for now (for our purposes it may not be needed, however it's likely that the logic inside it would have to be implemented somewhere anyway)
- I need to test all the various cases with our main codebase (2x2, different screen sizes, etc.)